### PR TITLE
디자인 전면 개편: MUI 제거 → Tailwind CSS + 다크모드 + 모바일 탭바

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,12 @@
-import React, { useState, useEffect, Suspense } from 'react';
+import React, { useEffect, Suspense } from 'react';
 import { HashRouter as Router, Route, Routes } from "react-router-dom";
 import ReactGA from "react-ga4";
 import { AuthProvider } from './contexts/AuthProvider';
+import { ThemeProvider } from './contexts/ThemeProvider';
 import routes from './routes/routes';
 import Footer from './components/layout/Footer';
 import Header from './components/layout/Header';
+import BottomNavBar from './components/layout/BottomNavBar';
 import './App.css';
 import Spinner from './components/common/Spinner';
 const trackingId = "G-2G1F6RJ26H"; // Google Analytics tracking ID
@@ -16,38 +18,42 @@ export default function App() {
   }, []);
 
   return (
-    <AuthProvider>
-    
-      <div className="flex flex-col min-h-screen bg-secondary text-primary">
-        <Router>
-          <Header />
+    <ThemeProvider>
+      <AuthProvider>
 
-          {/* 메인 라우팅 영역 */}
-          <div className="flex-grow">
-          <Suspense fallback={<Spinner />}>
-              <Routes>
-                {routes.map((route, index) => (
-                  <Route
-                    key={index}
-                    path={route.path}
-                    element={route.element}
-                  >
-                    {route.children && route.children.map((child, idx) => (
-                      <Route
-                        key={idx}
-                        path={child.path}
-                        element={child.element}
-                      />
-                    ))}
-                  </Route>
-                ))}
-              </Routes>
-            </Suspense>
-          </div>
+        <div className="flex flex-col min-h-screen bg-secondary dark:bg-dark-surface text-content-primary dark:text-white transition-colors duration-200">
+          <Router>
+            <Header />
 
-          <Footer />
-        </Router>
-      </div>
-    </AuthProvider>
+            {/* 메인 라우팅 영역 */}
+            <div className="flex-grow pb-nav-height md:pb-0">
+              <Suspense fallback={<Spinner />}>
+                <Routes>
+                  {routes.map((route, index) => (
+                    <Route
+                      key={index}
+                      path={route.path}
+                      element={route.element}
+                    >
+                      {route.children && route.children.map((child, idx) => (
+                        <Route
+                          key={idx}
+                          path={child.path}
+                          element={child.element}
+                        />
+                      ))}
+                    </Route>
+                  ))}
+                </Routes>
+              </Suspense>
+            </div>
+
+            <Footer />
+            {/* 모바일 하단 탭바 */}
+            <BottomNavBar />
+          </Router>
+        </div>
+      </AuthProvider>
+    </ThemeProvider>
   );
 }

--- a/src/api/axiosInstance.js
+++ b/src/api/axiosInstance.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const axiosInstance = axios.create({
+  baseURL: process.env.REACT_APP_API_URL,
+  withCredentials: true,
+});
+
+export default axiosInstance;

--- a/src/api/boardApi.js
+++ b/src/api/boardApi.js
@@ -1,35 +1,24 @@
-import axios from 'axios';
+import axiosInstance from './axiosInstance';
 
-export const initializePost = async ({categoryType}) => {
-  const response = await axios.post('/post/init', {categoryType}, { 
-    withCredentials: true });
-    console.log(response.data);
-  return response.data; 
+export const initializePost = async ({ categoryType }) => {
+  const response = await axiosInstance.post('/post/init', { categoryType });
+  return response.data;
 };
 
-export const createPost = ({ postId, title, contents, isTemp, categoryType,subCategoryType }) =>
-  axios.post(
-    '/post',
-    { postId, title, contents, isTemp, categoryType,subCategoryType },
-    { withCredentials: true }
-  );
+export const createPost = ({ postId, title, contents, isTemp, categoryType, subCategoryType }) =>
+  axiosInstance.post('/post', { postId, title, contents, isTemp, categoryType, subCategoryType });
 
 export const deletePost = async (postId) => {
-  const response = await axios.delete(`/post/${postId}`, {
-    withCredentials: true,
-  });
+  const response = await axiosInstance.delete(`/post/${postId}`);
   return response.data;
 };
 
 export const uploadFile = async ({ file, postId }) => {
-  console.log(file);
-  console.log(postId);
   const formData = new FormData();
   formData.append('file', file);
-  formData.append('postId', postId); 
-  const response = await axios.post(`/file/upload`, formData, {
+  formData.append('postId', postId);
+  const response = await axiosInstance.post('/file/upload', formData, {
     headers: { 'Content-Type': 'multipart/form-data' },
-    withCredentials: true,
   });
-  return response.data; // 이미지 URL 반환
+  return response.data;
 };

--- a/src/api/userApi.js
+++ b/src/api/userApi.js
@@ -1,22 +1,17 @@
-import axios from 'axios';
+import axiosInstance from './axiosInstance';
 
 export const joinUser = async (credentials) => {
-  const response = await axios.post('/user/join', credentials, { withCredentials: true });
+  const response = await axiosInstance.post('/user/join', credentials);
   return response.data;
 };
 
 export const sendEmailVerification = async (email) => {
-  const response = await axios.post(
-    '/user/sendEmail',
-    { email },
-    { headers: { 'Content-Type': 'application/json' } },
-     {withCredentials: true}
-  );
+  const response = await axiosInstance.post('/user/sendEmail', { email });
   if (response.status !== 200) throw new Error('Verification failed');
   return response.data;
 };
 
 export const loginUser = async (credentials) => {
-  const response = await axios.post('/user/login', credentials, { withCredentials: true });
+  const response = await axiosInstance.post('/user/login', credentials);
   return response.data;
 };

--- a/src/components/board/BoardCategorySelector.jsx
+++ b/src/components/board/BoardCategorySelector.jsx
@@ -1,47 +1,36 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  FormControl, 
-  FormLabel, 
-  Select, 
-  Option, 
-  Box, 
-  Typography, 
-  Tooltip
-} from '@mui/joy';
-import { 
-  BOARD_CATEGORIES, 
-  getOrderedMainCategories, 
-  getSubCategories 
+import {
+  BOARD_CATEGORIES,
+  getOrderedMainCategories,
+  getSubCategories,
 } from '../../constants/boardCategory';
 
+/**
+ * 카테고리 선택 컴포넌트 (MUI Joy 제거, 순수 Tailwind)
+ * - 메인 카테고리 선택 시 해당 하위 카테고리 드롭다운 표시
+ */
 const BoardCategorySelector = ({ selectedCategory, onCategoryChange }) => {
-  const [mainCategory, setMainCategory] = useState('');
-  const [subCategory, setSubCategory] = useState('');
-  const [availableSubCategories, setAvailableSubCategories] = useState([]);
+  const [mainCategory, setMainCategory]           = useState('');
+  const [subCategory, setSubCategory]             = useState('');
+  const [availableSubs, setAvailableSubs]         = useState([]);
   const mainCategories = getOrderedMainCategories();
 
-  // 선택된 카테고리 값이 외부에서 변경되는 경우 핸들링
+  /* 외부에서 selectedCategory 변경 시 동기화 */
   useEffect(() => {
-    if (selectedCategory) {
-      // 메인 카테고리인 경우
-      if (BOARD_CATEGORIES[selectedCategory]) {
-        setMainCategory(selectedCategory);
-        setSubCategory('');
-        // 해당 메인 카테고리의 하위 카테고리 가져오기
-        setAvailableSubCategories(getSubCategories(selectedCategory));
-      } 
-      // 하위 카테고리인 경우
-      else {
-        // 하위 카테고리에서 부모 카테고리 찾기
-        for (const mainCat of Object.values(BOARD_CATEGORIES)) {
-          if (mainCat.subCategories) {
-            for (const subCat of Object.values(mainCat.subCategories)) {
-              if (subCat.key === selectedCategory) {
-                setMainCategory(mainCat.key);
-                setSubCategory(selectedCategory);
-                setAvailableSubCategories(getSubCategories(mainCat.key));
-                break;
-              }
+    if (!selectedCategory) return;
+    if (BOARD_CATEGORIES[selectedCategory]) {
+      setMainCategory(selectedCategory);
+      setSubCategory('');
+      setAvailableSubs(getSubCategories(selectedCategory));
+    } else {
+      for (const mainCat of Object.values(BOARD_CATEGORIES)) {
+        if (mainCat.subCategories) {
+          for (const subCat of Object.values(mainCat.subCategories)) {
+            if (subCat.key === selectedCategory) {
+              setMainCategory(mainCat.key);
+              setSubCategory(selectedCategory);
+              setAvailableSubs(getSubCategories(mainCat.key));
+              break;
             }
           }
         }
@@ -49,87 +38,65 @@ const BoardCategorySelector = ({ selectedCategory, onCategoryChange }) => {
     }
   }, [selectedCategory]);
 
-  // 메인 카테고리 변경 핸들러
-  const handleMainCategoryChange = (event, newValue) => {
-    setMainCategory(newValue);
-    
-    // 하위 카테고리 목록 업데이트
-    const subCategories = getSubCategories(newValue);
-    setAvailableSubCategories(subCategories);
-    
-    // 하위 카테고리 초기화
+  const handleMainChange = (e) => {
+    const val = e.target.value;
+    setMainCategory(val);
+    const subs = getSubCategories(val);
+    setAvailableSubs(subs);
     setSubCategory('');
-    
-    // 부모 컴포넌트에 변경 알림
-    onCategoryChange(newValue, '');
+    onCategoryChange(val, '');
   };
 
-  // 하위 카테고리 변경 핸들러
-  const handleSubCategoryChange = (event, newValue) => {
-    setSubCategory(newValue);
-    
-    // 부모 컴포넌트에 변경 알림
-    onCategoryChange(mainCategory, newValue);
+  const handleSubChange = (e) => {
+    const val = e.target.value;
+    setSubCategory(val);
+    onCategoryChange(mainCategory, val);
   };
+
+  const selectClass =
+    'w-full px-3 py-2.5 rounded-xl text-sm ' +
+    'bg-surface dark:bg-dark-surface3 ' +
+    'border border-surface-3 dark:border-dark-border ' +
+    'text-content-primary dark:text-white ' +
+    'focus:outline-none focus:ring-2 focus:ring-primary/40 ' +
+    'transition duration-150 cursor-pointer';
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: 2, width: '100%' }}>
-      {/* 메인 카테고리 선택 */}
-      <FormControl sx={{ minWidth: { xs: '100%', sm: '50%' } }}>
-        <FormLabel>게시판 카테고리</FormLabel>
-        <Select
-          value={mainCategory}
-          onChange={handleMainCategoryChange}
-          placeholder="카테고리를 선택하세요"
-          required
-        >
-          {mainCategories.map((category) => (
-            <Option 
-              key={category.key} 
-              value={category.key}
-            >
-              <Tooltip title={category.description} placement="right">
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                  <Typography>{category.name}</Typography>
-                </Box>
-              </Tooltip>
-            </Option>
+    <div className="flex flex-col sm:flex-row gap-3 w-full">
+      {/* 메인 카테고리 */}
+      <div className="flex-1 flex flex-col gap-1">
+        <label className="text-sm font-medium text-content-primary dark:text-white">
+          게시판 카테고리 <span className="text-red-500">*</span>
+        </label>
+        <select value={mainCategory} onChange={handleMainChange} className={selectClass} required>
+          <option value="" disabled>카테고리를 선택하세요</option>
+          {mainCategories.map((cat) => (
+            <option key={cat.key} value={cat.key} title={cat.description}>
+              {cat.name}
+            </option>
           ))}
-        </Select>
-      </FormControl>
+        </select>
+      </div>
 
-      {/* 하위 카테고리 선택 (있는 경우에만) */}
-      {availableSubCategories.length > 0 && (
-        <FormControl sx={{ minWidth: { xs: '100%', sm: '50%' } }}>
-          <FormLabel>하위 카테고리</FormLabel>
-          <Select
-            value={subCategory}
-            onChange={handleSubCategoryChange}
-            placeholder="선택 (선택사항)"
-          >
-            <Option value="">선택 안함</Option>
-            {availableSubCategories.map((subCat) => (
-              <Option 
-                key={subCat.key} 
-                value={subCat.key}
-              >
-                <Tooltip title={subCat.description} placement="right">
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                    <Typography>{subCat.name}</Typography>
-                    {subCat.isNotice && (
-                      <Typography sx={{ fontSize: '0.75rem', color: 'warning.main' }}>
-                        공지
-                      </Typography>
-                    )}
-                  </Box>
-                </Tooltip>
-              </Option>
+      {/* 하위 카테고리 (있을 때만) */}
+      {availableSubs.length > 0 && (
+        <div className="flex-1 flex flex-col gap-1">
+          <label className="text-sm font-medium text-content-primary dark:text-white">
+            하위 카테고리
+            <span className="ml-1 text-xs text-content-disabled dark:text-gray-500">(선택사항)</span>
+          </label>
+          <select value={subCategory} onChange={handleSubChange} className={selectClass}>
+            <option value="">선택 안함</option>
+            {availableSubs.map((sub) => (
+              <option key={sub.key} value={sub.key} title={sub.description}>
+                {sub.name}{sub.isNotice ? ' 📢' : ''}
+              </option>
             ))}
-          </Select>
-        </FormControl>
+          </select>
+        </div>
       )}
-    </Box>
+    </div>
   );
 };
 
-export default BoardCategorySelector; 
+export default BoardCategorySelector;

--- a/src/components/board/BoardList.jsx
+++ b/src/components/board/BoardList.jsx
@@ -1,48 +1,202 @@
-import React from 'react';
-import Button from '@mui/material/Button';
-import { styled } from '@mui/material/styles';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell, { tableCellClasses } from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
-import Paper from '@mui/material/Paper';
-import Pagination from '@mui/material/Pagination';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import DateFormat from '../../utils/DateFormat';
-import { BOARD_CATEGORIES, getCategoryByKey } from '../../constants/boardCategory';
-import FilterAltIcon from '@mui/icons-material/FilterAlt';
-import FilterAltOffIcon from '@mui/icons-material/FilterAltOff';
+import { BOARD_CATEGORIES } from '../../constants/boardCategory';
+import { getCategoryInfo } from '../../utils/categoryUtils';
 
-const StyledTableCell = styled(TableCell)(() => ({
-  [`&.${tableCellClasses.head}`]: {
-    backgroundColor: 'var(--tw-bg-secondary)',
-    color: 'black',
-    textAlign: 'center',
-    fontSize: '0.875rem', // 14px
-    fontWeight: 'bold',
-    padding: '8px',
-    wordBreak: 'break-word',
-  },
-  [`&.${tableCellClasses.body}`]: {
-    fontSize: '0.875rem', // 14px
-    textAlign: 'center',
-    padding: '8px',
-    wordBreak: 'break-word',
-  },
-}));
+/* ── 카테고리 뱃지 ────────────────────────────────────────────── */
+const CategoryBadge = ({ categoryKey, small = false }) => {
+  const { name, color, isNotice } = getCategoryInfo(categoryKey);
+  return (
+    <span
+      className={`inline-flex items-center rounded-full font-semibold shrink-0
+                  ${small ? 'text-2xs px-1.5 py-0.5' : 'text-xs px-2 py-0.5'}`}
+      style={{ color, backgroundColor: `${color}18`, fontWeight: isNotice ? 700 : 600 }}
+    >
+      {name}
+    </span>
+  );
+};
 
-const StyledTableRow = styled(TableRow)(() => ({
-  '&:nth-of-type(odd)': {
-    backgroundColor: '#f9f9f9',
-  },
-  '&:last-child td, &:last-child th': {
-    border: 0,
-  },
-}));
+/* ── 페이지네이션 ──────────────────────────────────────────────── */
+const Pagination = ({ page, totalPages, onPageChange }) => {
+  if (totalPages <= 1) return null;
+  const pages = Array.from({ length: Math.min(totalPages, 7) }, (_, i) => {
+    if (totalPages <= 7) return i + 1;
+    if (page <= 4) return i + 1;
+    if (page >= totalPages - 3) return totalPages - 6 + i;
+    return page - 3 + i;
+  });
 
+  return (
+    <div className="flex items-center justify-center gap-1 mt-6">
+      <button
+        onClick={() => onPageChange(Math.max(1, page - 1))}
+        disabled={page === 1}
+        className="w-8 h-8 rounded-lg flex items-center justify-center text-sm
+                   text-content-secondary dark:text-gray-400
+                   hover:bg-surface-2 dark:hover:bg-dark-surface3
+                   disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+      >
+        ‹
+      </button>
+      {pages.map((p) => (
+        <button
+          key={p}
+          onClick={() => onPageChange(p)}
+          className={`w-8 h-8 rounded-lg flex items-center justify-center text-sm font-medium transition-colors
+            ${p === page
+              ? 'bg-primary text-white dark:bg-primary-light'
+              : 'text-content-secondary dark:text-gray-400 hover:bg-surface-2 dark:hover:bg-dark-surface3'
+            }`}
+        >
+          {p}
+        </button>
+      ))}
+      <button
+        onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+        disabled={page === totalPages}
+        className="w-8 h-8 rounded-lg flex items-center justify-center text-sm
+                   text-content-secondary dark:text-gray-400
+                   hover:bg-surface-2 dark:hover:bg-dark-surface3
+                   disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+      >
+        ›
+      </button>
+    </div>
+  );
+};
+
+/* ── 검색바 ──────────────────────────────────────────────────── */
+const SearchBar = ({ searchQuery, setSearchQuery, searchType, setSearchType, onSearch, recentSearches, onSelectRecent, onDeleteRecent }) => {
+  const [focused, setFocused] = useState(false);
+
+  return (
+    <div className="relative w-full max-w-lg mx-auto">
+      <div className="flex rounded-xl overflow-hidden border border-surface-3 dark:border-dark-border
+                      bg-surface dark:bg-dark-surface3
+                      focus-within:ring-2 focus-within:ring-primary/30 transition-all">
+        {/* 검색 유형 선택 */}
+        <select
+          value={searchType}
+          onChange={(e) => setSearchType(e.target.value)}
+          className="px-3 py-2.5 text-sm bg-surface-2 dark:bg-dark-surface3
+                     border-r border-surface-3 dark:border-dark-border
+                     text-content-primary dark:text-white focus:outline-none shrink-0"
+        >
+          <option value="title">제목</option>
+          <option value="content">내용</option>
+          <option value="writer">작성자</option>
+        </select>
+        {/* 검색어 입력 */}
+        <input
+          type="text"
+          placeholder="검색어를 입력하세요"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setTimeout(() => setFocused(false), 150)}
+          onKeyDown={(e) => e.key === 'Enter' && onSearch()}
+          className="flex-1 px-4 py-2.5 text-sm bg-transparent
+                     text-content-primary dark:text-white
+                     placeholder-content-disabled dark:placeholder-gray-500
+                     focus:outline-none"
+        />
+        {/* 검색 버튼 */}
+        <button
+          onClick={onSearch}
+          className="px-4 py-2 text-sm font-semibold
+                     bg-primary hover:bg-primary-dark text-white
+                     transition-colors duration-150 shrink-0"
+        >
+          검색
+        </button>
+      </div>
+
+      {/* 최근 검색어 드롭다운 */}
+      {focused && recentSearches.length > 0 && (
+        <div className="absolute top-full left-0 right-0 mt-1 z-20
+                        bg-surface dark:bg-dark-surface2
+                        border border-surface-3 dark:border-dark-border
+                        rounded-xl shadow-modal overflow-hidden">
+          <div className="px-4 py-2 text-xs text-content-secondary dark:text-gray-500 border-b border-surface-3 dark:border-dark-border">
+            최근 검색어
+          </div>
+          {recentSearches.map((s, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between px-4 py-2.5
+                         hover:bg-surface-2 dark:hover:bg-dark-surface3
+                         cursor-pointer"
+              onClick={() => onSelectRecent(s)}
+            >
+              <span className="text-sm text-content-primary dark:text-white">🕐 {s}</span>
+              <button
+                className="text-content-disabled dark:text-gray-500 hover:text-red-400 text-base leading-none"
+                onClick={(e) => { e.stopPropagation(); onDeleteRecent(i); }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/* ── 카테고리 필터 드롭다운 ─────────────────────────────────── */
+const CategoryFilter = ({ selectedCategory, onSelect }) => {
+  const [open, setOpen] = useState(false);
+  const { name } = selectedCategory ? getCategoryInfo(selectedCategory) : { name: '전체' };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 text-sm font-medium
+                   px-3 py-1.5 rounded-lg border border-surface-3 dark:border-dark-border
+                   bg-surface dark:bg-dark-surface3
+                   text-content-primary dark:text-white
+                   hover:bg-surface-2 dark:hover:bg-dark-surface2
+                   transition-colors duration-150"
+      >
+        <span>🏷</span>
+        {name}
+        <svg xmlns="http://www.w3.org/2000/svg" className={`w-3.5 h-3.5 transition-transform ${open ? 'rotate-180' : ''}`} viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full mt-1 z-20 w-40
+                        bg-surface dark:bg-dark-surface2
+                        border border-surface-3 dark:border-dark-border
+                        rounded-xl shadow-modal overflow-hidden">
+          <button
+            onClick={() => { onSelect(''); setOpen(false); }}
+            className={`w-full text-left px-4 py-2.5 text-sm transition-colors
+              ${!selectedCategory ? 'bg-primary/10 text-primary dark:text-primary-light font-semibold' : 'text-content-primary dark:text-white hover:bg-surface-2 dark:hover:bg-dark-surface3'}`}
+          >
+            전체 보기
+          </button>
+          {Object.values(BOARD_CATEGORIES).map((cat) => (
+            <button
+              key={cat.key}
+              onClick={() => { onSelect(cat.key); setOpen(false); }}
+              className={`w-full text-left px-4 py-2.5 text-sm transition-colors
+                ${selectedCategory === cat.key ? 'bg-primary/10 text-primary dark:text-primary-light font-semibold' : 'text-content-primary dark:text-white hover:bg-surface-2 dark:hover:bg-dark-surface3'}`}
+            >
+              {cat.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/* ── 메인 BoardList 컴포넌트 ────────────────────────────────── */
 const BoardList = ({
   posts,
   searchQuery,
@@ -52,445 +206,181 @@ const BoardList = ({
   page,
   onPageChange,
   selectedCategoryFilter,
-  onCategoryFilterChange
+  onCategoryFilterChange,
 }) => {
-  const isMobile = useMediaQuery('(max-width: 768px)');
   const totalPages = Math.ceil(totalPosts / 10);
-  const [searchType, setSearchType] = React.useState('title');
-  const [sortColumn, setSortColumn] = React.useState('latest');
-  const [recentSearches, setRecentSearches] = React.useState(
+  const [searchType, setSearchType] = useState('title');
+  const [sortColumn, setSortColumn] = useState('latest');
+  const [recentSearches, setRecentSearches] = useState(
     JSON.parse(localStorage.getItem('recentSearches') || '[]')
   );
-  const [showRecentSearches, setShowRecentSearches] = React.useState(false);
-  const [showCategoryFilter, setShowCategoryFilter] = React.useState(false);
 
-  // 검색 히스토리 저장
   const saveSearchHistory = (query) => {
     if (!query.trim()) return;
-    const searches = [...recentSearches];
-    const index = searches.indexOf(query);
-    if (index > -1) {
-      searches.splice(index, 1);
-    }
-    searches.unshift(query);
-    if (searches.length > 5) searches.pop();
-    setRecentSearches(searches);
-    localStorage.setItem('recentSearches', JSON.stringify(searches));
+    const list = [query, ...recentSearches.filter((s) => s !== query)].slice(0, 5);
+    setRecentSearches(list);
+    localStorage.setItem('recentSearches', JSON.stringify(list));
   };
 
-  // 검색 실행
   const executeSearch = () => {
     saveSearchHistory(searchQuery);
     handleSearch(searchType, sortColumn);
   };
 
-  // 컬럼 클릭 시 정렬 (좋아요만)
-  const handleColumnClick = (column) => {
-    if (column === 'likes') {
-      setSortColumn(prev => prev === 'likes' ? 'latest' : 'likes');
-    }
-  };
+  const handleToggleSort = () =>
+    setSortColumn((prev) => (prev === 'likes' ? 'latest' : 'likes'));
 
-  // 카테고리 표시 헬퍼 함수
-  const getCategoryInfo = (categoryKey) => {
-    if (!categoryKey) return { name: '미분류', color: '#999' };
-    
-    const categoryInfo = getCategoryByKey(categoryKey);
-    if (!categoryInfo) return { name: '미분류', color: '#999' };
-    
-    // 카테고리 정보에 따른 색상 결정
-    let color = '#4caf50'; // 기본 색상
-    
-    if (categoryInfo.isNotice) {
-      color = '#f44336'; // 공지사항은 빨간색
-    } else if (categoryKey.includes('FREE')) {
-      color = '#2196f3'; // 자유 카테고리는 파란색
-    } else if (categoryKey.includes('INFO')) {
-      color = '#ff9800'; // 정보공유는 주황색
-    } else if (categoryKey.includes('FUNNY')) {
-      color = '#9c27b0'; // 웃긴은 보라색
-    } else if (categoryKey.includes('BEGINNER')) {
-      color = '#009688'; // 초보 애견인은 청록색
-    }
-    
-    return {
-      name: categoryInfo.name,
-      color: color,
-      isNotice: categoryInfo.isNotice
-    };
-  };
+  return (
+    <main className="min-h-screen bg-secondary dark:bg-dark-surface transition-colors px-4 py-8">
+      <div className="max-w-6xl mx-auto">
 
-  // 카테고리 필터 핸들러
-  const handleCategoryFilterClick = (category) => {
-    onCategoryFilterChange(category);
-    setShowCategoryFilter(false);
-  };
-
-  if (isMobile) {
-    return (
-      <main className="board-container flex flex-col items-center bg-secondary min-h-screen px-2">
-        <div className="w-full max-w-md mt-8">
-          {/* 헤더 영역 */}
-          <div className="flex flex-row justify-between items-center mb-4">
-            <h2 className="text-xl font-bold text-primary">게시판</h2>
-            <Button
-              variant="contained"
-              component={Link}
-              to="/boardWrite"
-              size="small"
-              sx={{
-                bgcolor: '#4caf50',
-                '&:hover': { bgcolor: '#357a38' },
-              }}
-              className="text-sm font-semibold"
-            >
-              글쓰기
-            </Button>
-          </div>
-          
-          {/* 카테고리 필터 */}
-          <div className="mb-4">
-            <Button 
-              variant="outlined"
-              size="small"
-              startIcon={showCategoryFilter ? <FilterAltOffIcon /> : <FilterAltIcon />}
-              onClick={() => setShowCategoryFilter(!showCategoryFilter)}
-              sx={{ mb: 1 }}
-            >
-              {selectedCategoryFilter ? getCategoryInfo(selectedCategoryFilter).name : '카테고리 필터'}
-            </Button>
-            
-            {showCategoryFilter && (
-              <div className="bg-white p-2 shadow-md rounded">
-                <Button 
-                  variant="text" 
-                  size="small"
-                  onClick={() => handleCategoryFilterClick('')}
-                  className="w-full text-left justify-start mb-1"
-                  sx={{ color: selectedCategoryFilter === '' ? 'primary.main' : 'text.primary' }}
-                >
-                  전체 보기
-                </Button>
-                {Object.values(BOARD_CATEGORIES).map((category) => (
-                  <Button 
-                    key={category.key}
-                    variant="text" 
-                    size="small"
-                    onClick={() => handleCategoryFilterClick(category.key)}
-                    className="w-full text-left justify-start mb-1"
-                    sx={{ color: selectedCategoryFilter === category.key ? 'primary.main' : 'text.primary' }}
-                  >
-                    {category.name}
-                  </Button>
-                ))}
-              </div>
-            )}
-          </div>
-          
-          {/* 게시글 카드 목록 */}
-          <div className="space-y-4">
-            {posts.map((post) => {
-              const categoryInfo = getCategoryInfo(post.category);
-              return (
-                <div key={post.postId} className="p-4 bg-white rounded-lg shadow-md">
-                  <div className="flex justify-between items-start mb-1">
-                    <Link to={`/post/${post.postId}`} className="block flex-1">
-                      <h3 className="text-lg font-bold text-primary break-words">
-                        {post.title}
-                      </h3>
-                    </Link>
-                    <div 
-                      className="px-2 py-1 rounded text-xs ml-2"
-                      style={{ 
-                        backgroundColor: `${categoryInfo.color}20`, 
-                        color: categoryInfo.color,
-                        fontWeight: categoryInfo.isNotice ? 'bold' : 'normal'
-                      }}
-                    >
-                      {categoryInfo.name}
-                    </div>
-                  </div>
-                  <div className="mt-2 text-xs text-gray-500">
-                    <span>{DateFormat(post.regDate)}</span>
-                    <span className="mx-1">·</span>
-                    <span>{post.name}</span>
-                    <span className="mx-1">·</span>
-                    <span>조회수 {post.visitCount}</span>
-                    <span className="mx-1">·</span>
-                    <span>따봉 {post.likeCount}</span>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-          
-          {/* 검색 영역 */}
-          <div className="board-search mt-4 w-full max-w-md">
-            <div className="flex items-center gap-2">
-              <div className="relative flex-1">
-                <div className="flex">
-                  <select
-                    className="border-r-0 border-gray-300 rounded-l text-sm p-2"
-                    value={searchType}
-                    onChange={(e) => setSearchType(e.target.value)}
-                  >
-                    <option value="title">제목</option>
-                    <option value="content">내용</option>
-                    <option value="writer">작성자</option>
-                  </select>
-                  <input
-                    className="border border-l-0 border-gray-300 rounded-r text-sm p-2 flex-1"
-                    type="text"
-                    placeholder="검색어를 입력하세요"
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    onFocus={() => setShowRecentSearches(true)}
-                  />
-                </div>
-                {showRecentSearches && recentSearches.length > 0 && (
-                  <div className="absolute z-10 w-full bg-white border border-gray-300 rounded mt-1">
-                    {recentSearches.map((search, index) => (
-                      <div
-                        key={index}
-                        className="p-2 hover:bg-gray-100 cursor-pointer flex justify-between items-center"
-                        onClick={() => {
-                          setSearchQuery(search);
-                          setShowRecentSearches(false);
-                        }}
-                      >
-                        <span>{search}</span>
-                        <button
-                          className="text-gray-500 hover:text-gray-700"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            const newSearches = recentSearches.filter((_, i) => i !== index);
-                            setRecentSearches(newSearches);
-                            localStorage.setItem('recentSearches', JSON.stringify(newSearches));
-                          }}
-                        >
-                          ×
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-              <Button
-                variant="contained"
-                onClick={executeSearch}
-                size="small"
-                sx={{
-                  bgcolor: '#8B5E3C',
-                  '&:hover': { bgcolor: '#6F4B30' },
-                }}
-                className="text-sm"
-              >
-                검색
-              </Button>
-            </div>
-          </div>
-          
-          {/* 페이지네이션 */}
-          <div className="mt-4 flex justify-center">
-            <Pagination
-              count={totalPages}
-              variant="outlined"
-              shape="rounded"
-              page={page}
-              onChange={(event, value) => onPageChange(value)}
-              size="small"
+        {/* ── 헤더 ──────────────────────────────────── */}
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <h1 className="text-xl font-bold text-content-primary dark:text-white">게시판</h1>
+            <CategoryFilter
+              selectedCategory={selectedCategoryFilter}
+              onSelect={onCategoryFilterChange}
             />
           </div>
+          <Link
+            to="/boardWrite"
+            className="btn btn-primary text-sm"
+          >
+            ✏️ 글쓰기
+          </Link>
         </div>
-      </main>
-    );
-  } else {
-    return (
-      <main className="board-container flex flex-col items-center bg-secondary min-h-screen px-4 md:px-6">
-        <section className="board-section w-full max-w-6xl mt-8 bg-white dark:bg-rose-950 rounded-lg shadow-md overflow-hidden">
-          <div className="p-4">
-            {/* 헤더 영역 */}
-            <div className="board-header flex flex-row justify-between items-center w-full mb-4">
-              <div className="flex items-center">
-                <h2 className="board-title text-lg font-bold text-primary mr-4">
-                  게시판
-                </h2>
-                <div className="relative">
-                  <Button 
-                    variant="outlined"
-                    size="small"
-                    startIcon={showCategoryFilter ? <FilterAltOffIcon /> : <FilterAltIcon />}
-                    onClick={() => setShowCategoryFilter(!showCategoryFilter)}
-                  >
-                    {selectedCategoryFilter ? getCategoryInfo(selectedCategoryFilter).name : '카테고리 필터'}
-                  </Button>
-                  
-                  {showCategoryFilter && (
-                    <div className="absolute left-0 mt-1 bg-white p-2 shadow-md rounded z-10 w-40">
-                      <Button 
-                        variant="text" 
-                        size="small"
-                        onClick={() => handleCategoryFilterClick('')}
-                        className="w-full text-left justify-start mb-1"
-                        sx={{ color: selectedCategoryFilter === '' ? 'primary.main' : 'text.primary' }}
-                      >
-                        전체 보기
-                      </Button>
-                      {Object.values(BOARD_CATEGORIES).map((category) => (
-                        <Button 
-                          key={category.key}
-                          variant="text" 
-                          size="small"
-                          onClick={() => handleCategoryFilterClick(category.key)}
-                          className="w-full text-left justify-start mb-1"
-                          sx={{ color: selectedCategoryFilter === category.key ? 'primary.main' : 'text.primary' }}
-                        >
-                          {category.name}
-                        </Button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-              <Button
-                variant="contained"
-                component={Link}
-                to="/boardWrite"
-                size="small"
-                sx={{
-                  bgcolor: '#8B5E3C',
-                  '&:hover': { bgcolor: '#6F4B30' },
-                }}
-              >
-                글쓰기
-              </Button>
-            </div>
 
-            <hr className="board-divider my-4 border-gray-300 dark:border-gray-700" />
+        {/* ── PC: 테이블, 모바일: 카드 ─────────────── */}
 
-            {/* 테이블 영역 */}
-            <TableContainer component={Paper} className="board-table-container" style={{ overflowX: 'hidden' }}>
-              <Table className="w-full table-fixed" sx={{ minWidth: 700 }} aria-label="customized table">
-                <TableHead>
-                  <TableRow>
-            
-                    <StyledTableCell style={{ width: '65%' }}>
-                      제목
-                    </StyledTableCell>
-                    <StyledTableCell style={{ width: '10%' }}>닉네임</StyledTableCell>
-                    <StyledTableCell style={{ width: '10%' }}>날짜</StyledTableCell>
-                    <StyledTableCell style={{ width: '7%' }}>조회수</StyledTableCell>
-                    <StyledTableCell 
-                      style={{ width: '8%' }}
-                      onClick={() => handleColumnClick('likes')}
-                      sx={{ cursor: 'pointer' }}
-                    >
-                      따봉 {sortColumn === 'likes' && '▼'}
-                    </StyledTableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {posts.map((post) => {
-                    const categoryInfo = getCategoryInfo(post.category);
-                    return (
-                      <StyledTableRow key={post.postId}>
-                        <StyledTableCell component="th" scope="row">
-                          <Link to={`/post/${post.postId}`} className="hover:text-accent break-words">
-                            {post.title}
-                          </Link>
-                        </StyledTableCell>
-                        <StyledTableCell>{post.name}</StyledTableCell>
-                        <StyledTableCell>{DateFormat(post.regDate)}</StyledTableCell>
-                        <StyledTableCell>{post.visitCount}</StyledTableCell>
-                        <StyledTableCell>{post.likeCount}</StyledTableCell>
-                      </StyledTableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </TableContainer>
-            
-            {/* 검색 영역 */}
-            <div className="board-search mt-4 w-full max-w-md mx-auto">
-              <div className="flex items-center gap-2">
-                <div className="relative flex-1">
-                  <div className="flex">
-                    <select
-                      className="border-r-0 border-gray-300 rounded-l text-sm p-2"
-                      value={searchType}
-                      onChange={(e) => setSearchType(e.target.value)}
-                    >
-                      <option value="title">제목</option>
-                      <option value="content">내용</option>
-                      <option value="writer">작성자</option>
-                    </select>
-                    <input
-                      className="border border-gray-300 rounded text-sm p-2 flex-1"
-                      type="text"
-                      placeholder="검색어를 입력하세요"
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                      onFocus={() => setShowRecentSearches(true)}
-                    />
-                  </div>
-                  {showRecentSearches && recentSearches.length > 0 && (
-                    <div className="absolute z-10 w-full bg-white border border-gray-300 rounded mt-1">
-                      {recentSearches.map((search, index) => (
-                        <div
-                          key={index}
-                          className="p-2 hover:bg-gray-100 cursor-pointer flex justify-between items-center"
-                          onClick={() => {
-                            setSearchQuery(search);
-                            setShowRecentSearches(false);
-                          }}
-                        >
-                          <span>{search}</span>
-                          <button
-                            className="text-gray-500 hover:text-gray-700"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              const newSearches = recentSearches.filter((_, i) => i !== index);
-                              setRecentSearches(newSearches);
-                              localStorage.setItem('recentSearches', JSON.stringify(newSearches));
-                            }}
-                          >
-                            ×
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-                <Button
-                  variant="contained"
-                  onClick={executeSearch}
-                  size="medium"
-                  sx={{
-                    bgcolor: '#8B5E3C',
-                    '&:hover': { bgcolor: '#6F4B30' },
-                  }}
+        {/* 테이블 (md 이상) */}
+        <div className="hidden md:block bg-surface dark:bg-dark-surface2
+                        rounded-2xl shadow-card border border-surface-3 dark:border-dark-border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-surface-2 dark:bg-dark-surface3 border-b border-surface-3 dark:border-dark-border">
+                <th className="text-left px-4 py-3 font-semibold text-content-secondary dark:text-gray-400 w-[55%]">제목</th>
+                <th className="text-center px-3 py-3 font-semibold text-content-secondary dark:text-gray-400 w-[12%]">닉네임</th>
+                <th className="text-center px-3 py-3 font-semibold text-content-secondary dark:text-gray-400 w-[13%]">날짜</th>
+                <th className="text-center px-3 py-3 font-semibold text-content-secondary dark:text-gray-400 w-[8%]">조회</th>
+                <th
+                  className="text-center px-3 py-3 font-semibold text-content-secondary dark:text-gray-400 w-[8%] cursor-pointer hover:text-primary dark:hover:text-primary-light"
+                  onClick={handleToggleSort}
+                  title="클릭하여 좋아요 순 정렬"
                 >
-                  검색
-                </Button>
-              </div>
-            </div>
+                  따봉 {sortColumn === 'likes' ? '▼' : ''}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {posts.map((post) => (
+                  <tr
+                    key={post.postId}
+                    className="border-b border-surface-3 dark:border-dark-border last:border-0
+                               hover:bg-surface-2 dark:hover:bg-dark-surface3 transition-colors"
+                  >
+                    {/* 제목 */}
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <CategoryBadge categoryKey={post.category} small />
+                        <Link
+                          to={`/post/${post.postId}`}
+                          className="text-content-primary dark:text-white hover:text-primary dark:hover:text-primary-light
+                                     truncate transition-colors font-medium"
+                        >
+                          {post.title}
+                        </Link>
+                        {post.commentCount > 0 && (
+                          <span className="text-xs text-accent font-medium shrink-0">
+                            [{post.commentCount}]
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-3 py-3 text-center text-content-secondary dark:text-gray-400 truncate">
+                      {post.name}
+                    </td>
+                    <td className="px-3 py-3 text-center text-content-secondary dark:text-gray-400 text-xs">
+                      {DateFormat(post.regDate)}
+                    </td>
+                    <td className="px-3 py-3 text-center text-content-secondary dark:text-gray-400">
+                      {post.visitCount}
+                    </td>
+                    <td className="px-3 py-3 text-center font-medium">
+                      {post.likeCount > 0 ? (
+                        <span className="text-red-400">♥ {post.likeCount}</span>
+                      ) : (
+                        <span className="text-content-disabled dark:text-gray-600">-</span>
+                      )}
+                    </td>
+                  </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
 
-            {/* 페이지네이션 */}
-            <div className="board-pagination flex justify-center mt-4">
-              <Pagination
-                count={totalPages}
-                variant="outlined"
-                shape="rounded"
-                page={page}
-                onChange={(event, value) => onPageChange(value)}
-                size="medium"
-              />
-            </div>
-          </div>
-        </section>
-      </main>
-    );
-  }
+        {/* 카드 목록 (모바일) */}
+        <div className="md:hidden flex flex-col gap-3">
+          {posts.map((post) => (
+              <Link
+                key={post.postId}
+                to={`/post/${post.postId}`}
+                className="bg-surface dark:bg-dark-surface2
+                           rounded-2xl shadow-card p-4
+                           border border-surface-3 dark:border-dark-border
+                           active:scale-[0.99] transition-all duration-150"
+              >
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <CategoryBadge categoryKey={post.category} />
+                  <span className="text-xs text-content-disabled dark:text-gray-500">
+                    {DateFormat(post.regDate)}
+                  </span>
+                </div>
+                <h3 className="text-sm font-semibold text-content-primary dark:text-white line-clamp-2 mb-2">
+                  {post.title}
+                </h3>
+                <div className="flex items-center gap-2 text-xs text-content-secondary dark:text-gray-400">
+                  <span>{post.name}</span>
+                  <span>·</span>
+                  <span>조회 {post.visitCount}</span>
+                  {post.likeCount > 0 && (
+                    <>
+                      <span>·</span>
+                      <span className="text-red-400 font-medium">♥ {post.likeCount}</span>
+                    </>
+                  )}
+                  {post.commentCount > 0 && (
+                    <>
+                      <span>·</span>
+                      <span className="text-accent font-medium">💬 {post.commentCount}</span>
+                    </>
+                  )}
+                </div>
+              </Link>
+          ))}
+        </div>
+
+        {/* ── 검색 + 페이지네이션 ───────────────────── */}
+        <div className="mt-6 flex flex-col items-center gap-4">
+          <SearchBar
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+            searchType={searchType}
+            setSearchType={setSearchType}
+            onSearch={executeSearch}
+            recentSearches={recentSearches}
+            onSelectRecent={(s) => { setSearchQuery(s); }}
+            onDeleteRecent={(i) => {
+              const next = recentSearches.filter((_, idx) => idx !== i);
+              setRecentSearches(next);
+              localStorage.setItem('recentSearches', JSON.stringify(next));
+            }}
+          />
+          <Pagination page={page} totalPages={totalPages} onPageChange={onPageChange} />
+        </div>
+      </div>
+    </main>
+  );
 };
 
 export default BoardList;

--- a/src/components/board/MediaBlock.jsx
+++ b/src/components/board/MediaBlock.jsx
@@ -1,0 +1,64 @@
+import React, { useRef, useCallback } from 'react';
+import { SelectionState } from 'draft-js';
+
+/**
+ * Draft.js atomic block 렌더러 컴포넌트.
+ * BoardWriteContainer 밖에 선언하여 React.memo가 정상 동작합니다.
+ */
+const MediaBlock = React.memo((props) => {
+  const { block, contentState, blockProps } = props;
+  const { setSelection } = blockProps;
+  const entityKey = block.getEntityAt(0);
+  const videoRef = useRef(null);
+
+  const handleVideoFocus = useCallback(() => {
+    if (videoRef.current) {
+      videoRef.current.blur();
+    }
+  }, []);
+
+  const handleClick = useCallback(
+    (e) => {
+      e.stopPropagation();
+      const selection = SelectionState.createEmpty(block.getKey()).merge({
+        anchorOffset: 0,
+        focusOffset: 1,
+        hasFocus: true,
+      });
+      setSelection(selection);
+    },
+    [block, setSelection]
+  );
+
+  if (!entityKey) return null;
+
+  const entity = contentState.getEntity(entityKey);
+  const type = entity.getType();
+  const { src } = entity.getData();
+
+  return (
+    <div
+      data-draft-js-block="true"
+      className="atomic-block"
+      style={{ userSelect: 'none' }}
+      onClick={handleClick}
+    >
+      {type === 'IMAGE' ? (
+        <img src={src} alt="uploaded" style={{ maxWidth: '100%' }} />
+      ) : type === 'VIDEO' ? (
+        <video
+          ref={videoRef}
+          src={src}
+          controls
+          style={{ maxWidth: '100%' }}
+          onFocus={handleVideoFocus}
+          tabIndex="-1"
+        />
+      ) : null}
+    </div>
+  );
+});
+
+MediaBlock.displayName = 'MediaBlock';
+
+export default MediaBlock;

--- a/src/components/board/PostView.jsx
+++ b/src/components/board/PostView.jsx
@@ -1,80 +1,67 @@
-import React, { useState, useRef } from 'react';
-import { useMediaQuery } from '@mui/material';
-import Typography from '@mui/joy/Typography';
-import Card from '@mui/joy/Card';
-import Box from '@mui/joy/Box';
-import Button from '@mui/joy/Button';
-import FormControl from '@mui/joy/FormControl';
-import FormLabel from '@mui/joy/FormLabel';
-import Textarea from '@mui/joy/Textarea';
-import Sheet from '@mui/joy/Sheet';
-import Divider from '@mui/joy/Divider';
-import IconButton from '@mui/joy/IconButton';
-import { Link, useParams } from 'react-router-dom';
-import PetsIcon from '@mui/icons-material/Pets';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { sanitizeHtml } from '../../utils/sanitize';
 import DateFormat from '../../utils/DateFormat';
-import ShareIcon from '@mui/icons-material/Share';
-import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
-import NavigateNextIcon from '@mui/icons-material/NavigateNext';
-import DeleteIcon from '@mui/icons-material/Delete';
-import PreviewIcon from '@mui/icons-material/Preview';
-import ListIcon from '@mui/icons-material/List';
-import { getCategoryByKey } from '../../constants/boardCategory';
+import { getCategoryInfo } from '../../utils/categoryUtils';
 
+/* ── 댓글 카드 ────────────────────────────────────────────────── */
 function CommentCard({ comment, handleCommentLikeSubmit, handleCommentDelete }) {
+  const isDeleted = comment.status !== 'OPEN';
+  const isReply   = !!comment.parentCommentId;
+
   return (
-    <Card variant="outlined" sx={{ mb: 2, p: { xs: 1, md: 2 }, borderRadius: 2 }}>
-      <Box display="flex" alignItems="center" mb={1}>
-        {comment.parentCommentId && (
-          <ArrowDropDownIcon fontSize="small" sx={{ mr: 1 }} />
+    <div className={`${isReply ? 'ml-6 border-l-2 border-surface-3 dark:border-dark-border pl-4' : ''}`}>
+      <div className="py-4 border-b border-surface-3 dark:border-dark-border last:border-0">
+        {/* 메타 정보 */}
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-1.5">
+            {isReply && (
+              <svg className="w-3 h-3 text-content-disabled" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+              </svg>
+            )}
+            <span className="text-sm font-semibold text-content-primary dark:text-white">
+              {comment.name}
+            </span>
+          </div>
+          <span className="text-xs text-content-secondary dark:text-gray-400">
+            {DateFormat(comment.regDate)}
+          </span>
+        </div>
+
+        {/* 내용 */}
+        <p className={`text-sm leading-relaxed mb-3 ${isDeleted ? 'text-content-disabled dark:text-gray-500 italic' : 'text-content-primary dark:text-white'}`}>
+          {isDeleted ? '삭제된 댓글입니다.' : comment.contents}
+        </p>
+
+        {/* 액션 버튼 */}
+        {!isDeleted && (
+          <div className="flex items-center justify-end gap-2">
+            <button
+              onClick={() => handleCommentDelete(comment.commentId)}
+              className="text-xs font-medium text-content-secondary dark:text-gray-400
+                         hover:text-red-500 dark:hover:text-red-400 transition-colors"
+            >
+              삭제
+            </button>
+            <button
+              onClick={() => handleCommentLikeSubmit(comment.commentId)}
+              className="flex items-center gap-1 text-xs font-semibold
+                         px-3 py-1 rounded-full
+                         bg-primary/10 text-primary dark:bg-primary/20 dark:text-primary-light
+                         hover:bg-primary/20 dark:hover:bg-primary/30
+                         transition-colors duration-150"
+            >
+              🐾 {comment.likeCount}
+            </button>
+          </div>
         )}
-        <Typography variant="subtitle1" fontWeight="bold" sx={{ fontSize: { xs: '0.75rem', md: 'inherit' } }}>
-          {comment.name}
-        </Typography>
-        <Box flexGrow={1} />
-        <Typography variant="caption" color="text.secondary" sx={{ fontSize: { xs: '0.65rem', md: 'inherit' } }}>
-          {DateFormat(comment.regDate)}
-        </Typography>
-      </Box>
-      <Typography variant="body2" mb={1} sx={{ fontSize: { xs: '0.7rem', md: 'inherit' } }}>
-        {comment.status === "OPEN" ? comment.contents : '삭제된 댓글입니다.'}
-      </Typography>
-      <Box display="flex" justifyContent="flex-end" gap={1}>
-        <Button
-          onClick={() => handleCommentDelete(comment.commentId)}
-          size="sm"
-          startDecorator={<DeleteIcon fontSize="small" />}
-          variant="outlined"
-          sx={{
-            color: '#8B5E3C',
-            borderColor: '#8B5E3C',
-            '&:hover': { borderColor: '#6F4B30', color: '#6F4B30' },
-            fontSize: { xs: '0.65rem', md: '0.75rem' },
-            py: 0.5
-          }}
-        >
-          삭제
-        </Button>
-        <Button
-          onClick={() => handleCommentLikeSubmit(comment.commentId)}
-          size="sm"
-          startDecorator={<PetsIcon fontSize="small" />}
-          variant="solid"
-          sx={{
-            bgcolor: '#8B5E3C',
-            '&:hover': { bgcolor: '#6F4B30' },
-            color: 'white',
-            fontSize: { xs: '0.65rem', md: '0.75rem' },
-            py: 0.5
-          }}
-        >
-          {comment.likeCount}
-        </Button>
-      </Box>
-      {comment.children && comment.children.length > 0 && (
-        <Box sx={{ ml: 3, mt: 1 }}>
-          {comment.children.map(child => (
+      </div>
+
+      {/* 대댓글 */}
+      {comment.children?.length > 0 && (
+        <div>
+          {comment.children.map((child) => (
             <CommentCard
               key={child.commentId}
               comment={child}
@@ -82,41 +69,13 @@ function CommentCard({ comment, handleCommentLikeSubmit, handleCommentDelete }) 
               handleCommentDelete={handleCommentDelete}
             />
           ))}
-        </Box>
+        </div>
       )}
-    </Card>
+    </div>
   );
 }
 
-// 카테고리 정보 가져오는 헬퍼 함수
-const getCategoryInfo = (categoryKey) => {
-  if (!categoryKey) return { name: '미분류', color: '#999' };
-  
-  const categoryInfo = getCategoryByKey(categoryKey);
-  if (!categoryInfo) return { name: '미분류', color: '#999' };
-  
-  // 카테고리 정보에 따른 색상 결정
-  let color = '#4caf50'; // 기본 색상
-  
-  if (categoryInfo.isNotice) {
-    color = '#f44336'; // 공지사항은 빨간색
-  } else if (categoryKey.includes('FREE')) {
-    color = '#2196f3'; // 자유 카테고리는 파란색
-  } else if (categoryKey.includes('INFO')) {
-    color = '#ff9800'; // 정보공유는 주황색
-  } else if (categoryKey.includes('FUNNY')) {
-    color = '#9c27b0'; // 웃긴은 보라색
-  } else if (categoryKey.includes('BEGINNER')) {
-    color = '#009688'; // 초보 애견인은 청록색
-  }
-  
-  return {
-    name: categoryInfo.name,
-    color: color,
-    isNotice: categoryInfo.isNotice
-  };
-};
-
+/* ── PostView 메인 컴포넌트 ──────────────────────────────────── */
 const PostView = ({
   posts,
   handleLikeSubmit,
@@ -131,293 +90,175 @@ const PostView = ({
   prevPostId,
   nextPostId,
 }) => {
-  
   const [showPreview, setShowPreview] = useState(false);
-  const isMobile = useMediaQuery('(max-width:600px)');
   const categoryKey = posts.category?.categoryType;
+  const catInfo     = categoryKey ? getCategoryInfo(categoryKey) : null;
+
   return (
-    <main className="flex flex-col items-center bg-secondary min-h-screen" style={{ padding: isMobile ? '8px' : '20px' }}>
-      <section className="w-full max-w-6xl mt-8 bg-white rounded-lg shadow-md overflow-hidden" style={{ margin: isMobile ? '8px' : '20px auto' }}>
-        <div style={{ padding: isMobile ? '12px' : '24px' }}>
-          {/* 헤더 */}
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: isMobile ? '10px' : '20px' }}>
-            <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ fontWeight: '600', color: '#2C1810' }}>
-              정보 공유
-            </Typography>
-            <Button
-              component={Link}
-              to="/board"
-              startDecorator={<ListIcon />}
-              variant="outlined"
-              size={isMobile ? 'sm' : 'md'}
-              sx={{
-                color: '#8B5E3C',
-                borderColor: '#8B5E3C',
-                '&:hover': { borderColor: '#6F4B30', color: '#6F4B30' },
-                fontSize: isMobile ? '0.65rem' : '0.875rem'
-              }}
-            >
-              목록으로
-            </Button>
-          </div>
-          {/* 게시글 내용 */}
-          <Card variant="outlined" sx={{ p: isMobile ? 2 : 4, bgcolor: 'background.surface' }}>
-            <Box display="flex" justifyContent="space-between" mb={isMobile ? 1 : 2}>
-              <Box display="flex" alignItems="center" gap={1}>
-              
-                {posts.category && (
-                  <Box
-                    component="span"
-                    sx={{
-                      display: 'inline-block',
-                      px: 1,
-                      py: 0.5,
-                      borderRadius: 1,
-                      fontSize: isMobile ? '0.7rem' : '0.8rem',
-                      fontWeight: getCategoryInfo(categoryKey).isNotice ? 'bold' : 'normal',
-                      backgroundColor: `${getCategoryInfo(categoryKey).color}20`,
-                      color: getCategoryInfo(categoryKey).color,
-                    }}
-                  >
-                    {getCategoryInfo(categoryKey).name}
-                  </Box>
-                )}
-                <Typography
-                  component="h3"
-                  sx={{
-                    fontSize: isMobile ? '1rem' : '1.25rem',
-                    fontWeight: 'bold',
-                    color: '#2C1810'
-                  }}
-                >
-                  {posts.title}
-                </Typography>
-              </Box>
-              <Typography sx={{ fontSize: isMobile ? '0.65rem' : '0.875rem', color: 'text.secondary' }}>
-                {DateFormat(posts.regDate)}
-              </Typography>
-            </Box>
-            <Box display="flex" justifyContent="space-between" mb={isMobile ? 1 : 3}>
-              <Typography sx={{ fontSize: isMobile ? '0.65rem' : '0.875rem', color: 'text.secondary' }}>
-                작성자 : {posts.name}
-              </Typography>
-              <Box display="flex" gap={isMobile ? 1 : 2}>
-                <Box display="flex" alignItems="center" gap={0.5}>
-                  <Typography sx={{ fontSize: isMobile ? '0.55rem' : '0.75rem', color: 'text.secondary' }}>
-                    조회수
-                  </Typography>
-                  <Typography sx={{ fontSize: isMobile ? '0.55rem' : '0.75rem', fontWeight: 'medium' }}>
-                    {posts.visitCount}
-                  </Typography>
-                </Box>
-                <Box display="flex" alignItems="center" gap={0.5}>
-                  <Typography sx={{ fontSize: isMobile ? '0.55rem' : '0.75rem', color: 'text.secondary' }}>
-                    따봉
-                  </Typography>
-                  <Typography sx={{ fontSize: isMobile ? '0.55rem' : '0.75rem', fontWeight: 'medium' }}>
-                    {posts.likeCount}
-                  </Typography>
-                </Box>
-              </Box>
-            </Box>
-            <Divider sx={{ my: isMobile ? 1 : 3 }} />
-            <Box display="flex" justifyContent="flex-end" mb={isMobile ? 1 : 2}>
-              <Button
-                onClick={handleShare}
-                startDecorator={<ShareIcon sx={{ fontSize: isMobile ? '0.8rem' : '1rem' }} />}
-                variant="outlined"
-                size={isMobile ? 'sm' : 'md'}
-                sx={{
-                  color: '#8B5E3C',
-                  borderColor: '#8B5E3C',
-                  '&:hover': { borderColor: '#6F4B30', color: '#6F4B30' },
-                  fontSize: isMobile ? '0.65rem' : '0.75rem',
-                  py: isMobile ? 0.3 : 0.5,
-                  px: isMobile ? 1 : 1.5,
-                }}
-              >
-                공유
-              </Button>
-            </Box>
-            <Typography
-              component="div"
-              sx={{
-                mb: isMobile ? 2 : 4,
-                '& img': { maxWidth: '100%', height: 'auto' },
-                '& p': { mb: 2 },
-                lineHeight: 1.6,
-                fontSize: isMobile ? '0.65rem' : '0.875rem'
-              }}
-            >
-              <div dangerouslySetInnerHTML={{ __html: posts.contents }} />
-            </Typography>
-            <Box display="flex" flexDirection="column" gap={isMobile ? 1 : 2} mb={isMobile ? 2 : 3}
-              sx={{ opacity: 0.8, transition: 'opacity 0.2s', '&:hover': { opacity: 1 } }}
-            >
-              <Box display="flex" justifyContent="center" gap={isMobile ? 0.5 : 1}>
-                <Button
-                  component={Link}
-                  to={prevPostId ? `/post/${prevPostId}` : '#'}
-                  disabled={!prevPostId}
-                  startDecorator={<NavigateBeforeIcon sx={{ fontSize: isMobile ? '0.8rem' : '1rem' }} />}
-                  variant="outlined"
-                  size={isMobile ? 'sm' : 'md'}
-                  sx={{
-                    color: '#8B5E3C',
-                    borderColor: '#8B5E3C',
-                    '&:hover': { borderColor: '#6F4B30', color: '#6F4B30' },
-                    fontSize: isMobile ? '0.65rem' : '0.75rem',
-                    py: isMobile ? 0.3 : 0.5,
-                    minHeight: '24px',
-                    opacity: prevPostId ? 1 : 0.5
-                  }}
-                >
-                  이전글
-                </Button>
-                <Button
-                  component={Link}
-                  to={nextPostId ? `/post/${nextPostId}` : '#'}
-                  disabled={!nextPostId}
-                  endDecorator={<NavigateNextIcon sx={{ fontSize: isMobile ? '0.8rem' : '1rem' }} />}
-                  variant="outlined"
-                  size={isMobile ? 'sm' : 'md'}
-                  sx={{
-                    color: '#8B5E3C',
-                    borderColor: '#8B5E3C',
-                    '&:hover': { borderColor: '#6F4B30', color: '#6F4B30' },
-                    fontSize: isMobile ? '0.65rem' : '0.75rem',
-                    py: isMobile ? 0.3 : 0.5,
-                    minHeight: '24px',
-                    opacity: nextPostId ? 1 : 0.5
-                  }}
-                >
-                  다음글
-                </Button>
-              </Box>
-            </Box>
-            <Box display="flex" justifyContent="center" mb={isMobile ? 2 : 4}>
-              <Button
-                sx={{
-                  px: isMobile ? 2 : 4,
-                  bgcolor: '#4caf50',
-                  '&:hover': { bgcolor: '#357a38' },
-                  color: 'white',
-                  transition: 'transform 0.5s',
-                  '&:hover': { transform: 'scale(1.05)' },
-                  fontSize: isMobile ? '0.75rem' : '0.875rem',
-                }}
-                startDecorator={<PetsIcon />}
-                onClick={handleLikeSubmit}
-              >
-                따봉 {posts.likeCount}
-              </Button>
-            </Box>
-            {totalComments > 0 && (
-              <Sheet
-                variant="outlined"
-                sx={{
-                  p: isMobile ? 2 : 3,
-                  mt: isMobile ? 2 : 4,
-                  borderRadius: 'sm',
-                  bgcolor: 'background.level1'
-                }}
-              >
-                <Typography
-                  level="h6"
-                  sx={{
-                    mb: isMobile ? 1 : 3,
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1,
-                    color: 'text.primary',
-                    fontSize: isMobile ? '0.75rem' : '0.875rem',
-                  }}
-                >
-                  댓글 <Typography component="span" sx={{ color: '#4caf50' }}>{totalComments}</Typography>
-                </Typography>
-                {comments.map((comment) => (
-                  <CommentCard
-                    key={comment.commentId}
-                    comment={comment}
-                    handleCommentLikeSubmit={handleCommentLikeSubmit}
-                    handleCommentDelete={handleCommentDelete}
-                  />
-                ))}
-              </Sheet>
-            )}
-            <Card
-              variant="outlined"
-              sx={{
-                mt: isMobile ? 2 : 4,
-                p: isMobile ? 2 : 3,
-                bgcolor: 'background.level1'
-              }}
-            >
-              <FormControl>
-                <FormLabel sx={{ mb: 2, color: 'text.primary', fontSize: isMobile ? '0.75rem' : 'inherit' }}>
-                  댓글 작성
-                </FormLabel>
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                  <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
-                    <Typography level="body2" sx={{ color: 'text.secondary', fontSize: isMobile ? '0.65rem' : 'inherit' }}>
-                      {content.length}/500자
-                    </Typography>
-                    <IconButton
-                      size="sm"
-                      variant="plain"
-                      sx={{ color: 'text.secondary', '&:hover': { color: 'text.primary' } }}
-                      onClick={() => setShowPreview(!showPreview)}
-                    >
-                      <PreviewIcon sx={{ fontSize: '1.25rem' }} />
-                    </IconButton>
-                  </Box>
-                  {showPreview ? (
-                    <Box
-                      sx={{
-                        p: 2,
-                        borderRadius: 'sm',
-                        bgcolor: 'background.surface',
-                        minHeight: '100px',
-                        border: '1px solid',
-                        borderColor: 'divider'
-                      }}
-                    >
-                      {content || '내용이 없습니다.'}
-                    </Box>
-                  ) : (
-                    <Textarea
-                      placeholder="댓글을 입력해주세요..."
-                      value={content}
-                      onChange={(e) => setContent(e.target.value)}
-                      minRows={3}
-                      maxLength={500}
-                      sx={{
-                        width: '100%',
-                        mb: 2,
-                        '&:hover': { borderColor: '#8B5E3C' },
-                        '&:focus-within': { borderColor: '#8B5E3C', boxShadow: '0 0 0 3px rgba(139, 94, 60, 0.1)' }
-                      }}
-                    />
-                  )}
-                  <Button
-                    sx={{
-                      alignSelf: 'flex-end',
-                      bgcolor: '#4caf50',
-                      '&:hover': { bgcolor: '#357a38' },
-                      color: 'white',
-                      px: 3,
-                      fontSize: isMobile ? '0.75rem' : 'inherit'
-                    }}
-                    onClick={handleCommentSubmit}
-                  >
-                    댓글 작성
-                  </Button>
-                </Box>
-              </FormControl>
-            </Card>
-          </Card>
+    <main className="min-h-screen bg-secondary dark:bg-dark-surface transition-colors px-4 py-8">
+      <div className="max-w-3xl mx-auto">
+
+        {/* ── 상단: 목록 버튼 ────────────────────────── */}
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-lg font-bold text-content-primary dark:text-white">
+            게시글
+          </h1>
+          <Link to="/board" className="btn btn-secondary text-sm">
+            ☰ 목록으로
+          </Link>
         </div>
-      </section>
+
+        {/* ── 게시글 본문 ───────────────────────────── */}
+        <article className="bg-surface dark:bg-dark-surface2
+                            rounded-2xl shadow-card border border-surface-3 dark:border-dark-border
+                            p-6 md:p-8 mb-4">
+
+          {/* 카테고리 + 제목 */}
+          <div className="mb-4">
+            {catInfo && (
+              <span
+                className="inline-flex items-center text-xs font-semibold px-2.5 py-1 rounded-full mb-3"
+                style={{ color: catInfo.color, backgroundColor: `${catInfo.color}18` }}
+              >
+                {catInfo.name}
+              </span>
+            )}
+            <h2 className="text-xl md:text-2xl font-bold text-content-primary dark:text-white leading-tight">
+              {posts.title}
+            </h2>
+          </div>
+
+          {/* 메타 정보 */}
+          <div className="flex flex-wrap items-center justify-between gap-2 mb-6
+                          pb-4 border-b border-surface-3 dark:border-dark-border">
+            <div className="flex items-center gap-3 text-sm text-content-secondary dark:text-gray-400">
+              <span className="font-medium">{posts.name}</span>
+              <span>·</span>
+              <span>{DateFormat(posts.regDate)}</span>
+            </div>
+            <div className="flex items-center gap-3 text-xs text-content-secondary dark:text-gray-400">
+              <span>조회 {posts.visitCount}</span>
+              <span>·</span>
+              <span>따봉 {posts.likeCount}</span>
+              {/* 공유 버튼 */}
+              <button
+                onClick={handleShare}
+                className="flex items-center gap-1 text-xs text-content-secondary dark:text-gray-400
+                           hover:text-primary dark:hover:text-primary-light transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13" />
+                </svg>
+                공유
+              </button>
+            </div>
+          </div>
+
+          {/* 본문 HTML */}
+          <div
+            className="prose prose-sm max-w-none text-content-primary dark:text-white
+                       [&_img]:max-w-full [&_img]:rounded-lg [&_p]:mb-4 [&_p]:leading-relaxed"
+            dangerouslySetInnerHTML={{ __html: sanitizeHtml(posts.contents) }}
+          />
+
+          {/* 따봉 버튼 */}
+          <div className="flex justify-center mt-8 mb-4">
+            <button
+              onClick={handleLikeSubmit}
+              className="flex items-center gap-2 px-8 py-3 rounded-full
+                         bg-accent/10 text-accent hover:bg-accent/20
+                         dark:bg-accent/20 dark:hover:bg-accent/30
+                         font-bold text-lg transition-all duration-150
+                         hover:scale-105 active:scale-95"
+            >
+              🐾 따봉 {posts.likeCount}
+            </button>
+          </div>
+
+          {/* 이전글 / 다음글 */}
+          <div className="flex items-center justify-center gap-3 mt-6 pt-4 border-t border-surface-3 dark:border-dark-border">
+            <Link
+              to={prevPostId ? `/post/${prevPostId}` : '#'}
+              className={`btn btn-secondary text-sm ${!prevPostId ? 'opacity-40 pointer-events-none' : ''}`}
+            >
+              ← 이전글
+            </Link>
+            <Link
+              to={nextPostId ? `/post/${nextPostId}` : '#'}
+              className={`btn btn-secondary text-sm ${!nextPostId ? 'opacity-40 pointer-events-none' : ''}`}
+            >
+              다음글 →
+            </Link>
+          </div>
+        </article>
+
+        {/* ── 댓글 목록 ─────────────────────────────── */}
+        {totalComments > 0 && (
+          <section className="bg-surface dark:bg-dark-surface2
+                              rounded-2xl shadow-card border border-surface-3 dark:border-dark-border
+                              p-6 mb-4">
+            <h3 className="text-base font-bold text-content-primary dark:text-white mb-4">
+              댓글{' '}
+              <span className="text-accent font-bold">{totalComments}</span>
+            </h3>
+            {comments.map((comment) => (
+              <CommentCard
+                key={comment.commentId}
+                comment={comment}
+                handleCommentLikeSubmit={handleCommentLikeSubmit}
+                handleCommentDelete={handleCommentDelete}
+              />
+            ))}
+          </section>
+        )}
+
+        {/* ── 댓글 작성 ─────────────────────────────── */}
+        <section className="bg-surface dark:bg-dark-surface2
+                            rounded-2xl shadow-card border border-surface-3 dark:border-dark-border
+                            p-6">
+          <div className="flex items-center justify-between mb-3">
+            <label className="text-base font-bold text-content-primary dark:text-white">
+              댓글 작성
+            </label>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-content-secondary dark:text-gray-400">
+                {content.length}/500자
+              </span>
+              <button
+                onClick={() => setShowPreview((v) => !v)}
+                className="text-xs font-medium text-primary dark:text-primary-light
+                           hover:underline transition-colors"
+              >
+                {showPreview ? '편집' : '미리보기'}
+              </button>
+            </div>
+          </div>
+
+          {showPreview ? (
+            <div className="min-h-[100px] px-4 py-3 rounded-xl
+                            bg-surface-2 dark:bg-dark-surface3
+                            border border-surface-3 dark:border-dark-border
+                            text-sm text-content-primary dark:text-white leading-relaxed whitespace-pre-wrap">
+              {content || <span className="text-content-disabled italic">내용이 없습니다.</span>}
+            </div>
+          ) : (
+            <textarea
+              rows={4}
+              maxLength={500}
+              placeholder="댓글을 입력해주세요..."
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              className="input resize-none mb-4"
+            />
+          )}
+
+          <div className="flex justify-end mt-3">
+            <button onClick={handleCommentSubmit} className="btn btn-accent">
+              댓글 작성
+            </button>
+          </div>
+        </section>
+      </div>
     </main>
   );
 };

--- a/src/components/common/Loading.jsx
+++ b/src/components/common/Loading.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
-import {Background, LoadingText} from '../../utils/Style.js';
-import Spinner from '../../assets/loading.gif';
+import loadingGif from '../../assets/loading.gif';
 
+/**
+ * DBTI 전용 로딩 컴포넌트 (styled-components 제거, 순수 Tailwind)
+ */
 export default function Loading() {
   return (
-    <Background>
-      <LoadingText><p className='text-4xl font-bold'>너네 강아지 MBTI 뭐야?</p></LoadingText>
-      <br/>
-      <img src={Spinner} alt="로딩중" width="5%" />
-    </Background>
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center
+                    bg-secondary dark:bg-dark-surface">
+      <p className="text-2xl font-bold text-primary dark:text-primary-light mb-6">
+        너네 강아지 MBTI 뭐야?
+      </p>
+      <img src={loadingGif} alt="로딩중" className="w-20 h-20" />
+    </div>
   );
-};
+}

--- a/src/components/common/Spinner.jsx
+++ b/src/components/common/Spinner.jsx
@@ -1,15 +1,22 @@
 import React from 'react';
-import { Background, LoadingText } from '../../utils/Style.js';
 
+/**
+ * 전체화면 로딩 스피너 (styled-components 제거, 순수 Tailwind)
+ * Suspense fallback 및 페이지 전환 로딩에 사용
+ */
 const Spinner = () => {
   return (
-    <Background>
-      <LoadingText>
-        <p className="text-4xl font-bold">로딩...</p>
-      </LoadingText>
-      <br />
-      <img src={`${process.env.PUBLIC_URL}/images/borikkori_loading_spinner.gif`} alt="로딩중" width="80px" />
-    </Background>
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center
+                    bg-secondary dark:bg-dark-surface">
+      <img
+        src={`${process.env.PUBLIC_URL}/images/borikkori_loading_spinner.gif`}
+        alt="로딩중"
+        className="w-20 h-20"
+      />
+      <p className="mt-4 text-base font-semibold text-primary dark:text-primary-light">
+        로딩중...
+      </p>
+    </div>
   );
 };
 

--- a/src/components/common/UserAvatar.jsx
+++ b/src/components/common/UserAvatar.jsx
@@ -1,16 +1,29 @@
-import * as React from 'react';
-import { Avatar, Chip } from "@mui/material";
+import React from 'react';
 
-export default function UserAvatar({ userName }) {
+/**
+ * 사용자 아바타 컴포넌트 (MUI 제거, 순수 Tailwind)
+ * - 이미지가 없으면 이름 첫 글자 이니셜 표시
+ * - size: 'sm'|'md' (기본: 'md')
+ */
+export default function UserAvatar({ userName, size = 'md' }) {
+  const initial = userName ? userName.charAt(0).toUpperCase() : '?';
+
+  const sizeClasses = {
+    sm: 'w-7 h-7 text-xs',
+    md: 'w-9 h-9 text-sm',
+  };
+
   return (
-    <Chip
-      avatar={<Avatar alt="logo" src="/images/borikkori_logo.png" />}
-      label={userName}
-      variant="outlined"
-      sx={{ 
-        fontWeight: "bold",   
-        color: "white",
-        fontSize: "0.875rem" }} 
-    />
+    <div
+      title={userName}
+      className={`
+        ${sizeClasses[size] ?? sizeClasses.md}
+        flex items-center justify-center rounded-full shrink-0
+        bg-white/20 border border-white/30
+        font-bold text-white select-none
+      `}
+    >
+      {initial}
+    </div>
   );
 }

--- a/src/components/layout/BottomNavBar.jsx
+++ b/src/components/layout/BottomNavBar.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+/**
+ * 모바일 전용 하단 탭 내비게이션 (md 이상에서 숨김)
+ * Toss/당근마켓 스타일
+ */
+
+const tabs = [
+  {
+    to: '/',
+    label: '홈',
+    end: true,
+    icon: (active) => (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6" fill={active ? 'currentColor' : 'none'} viewBox="0 0 24 24" stroke="currentColor" strokeWidth={active ? 0 : 1.8}>
+        <path strokeLinecap="round" strokeLinejoin="round"
+          d="M2.25 12l8.954-8.955a1.126 1.126 0 011.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+      </svg>
+    ),
+  },
+  {
+    to: '/board',
+    label: '게시판',
+    end: false,
+    icon: (active) => (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6" fill={active ? 'currentColor' : 'none'} viewBox="0 0 24 24" stroke="currentColor" strokeWidth={active ? 0 : 1.8}>
+        <path strokeLinecap="round" strokeLinejoin="round"
+          d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25H12" />
+      </svg>
+    ),
+  },
+  {
+    to: '/chat',
+    label: '채팅',
+    end: false,
+    icon: (active) => (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6" fill={active ? 'currentColor' : 'none'} viewBox="0 0 24 24" stroke="currentColor" strokeWidth={active ? 0 : 1.8}>
+        <path strokeLinecap="round" strokeLinejoin="round"
+          d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
+      </svg>
+    ),
+  },
+  {
+    to: '/map',
+    label: '지도',
+    end: false,
+    icon: (active) => (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6" fill={active ? 'currentColor' : 'none'} viewBox="0 0 24 24" stroke="currentColor" strokeWidth={active ? 0 : 1.8}>
+        <path strokeLinecap="round" strokeLinejoin="round"
+          d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
+        <path strokeLinecap="round" strokeLinejoin="round"
+          d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" />
+      </svg>
+    ),
+  },
+  {
+    to: '/games',
+    label: '게임',
+    end: false,
+    icon: (active) => (
+      <svg xmlns="http://www.w3.org/2000/svg" className="w-6 h-6" fill={active ? 'currentColor' : 'none'} viewBox="0 0 24 24" stroke="currentColor" strokeWidth={active ? 0 : 1.8}>
+        <path strokeLinecap="round" strokeLinejoin="round"
+          d="M14.25 6.087c0-.355.186-.676.401-.959.221-.29.349-.634.349-1.003 0-1.036-1.007-1.875-2.25-1.875s-2.25.84-2.25 1.875c0 .369.128.713.349 1.003.215.283.401.604.401.959v0a.64.64 0 01-.657.643 48.39 48.39 0 01-4.163-.3c.186 1.613.293 3.25.315 4.907a.656.656 0 01-.658.663v0c-.355 0-.676-.186-.959-.401a1.647 1.647 0 00-1.003-.349c-1.036 0-1.875 1.007-1.875 2.25s.84 2.25 1.875 2.25c.369 0 .713-.128 1.003-.349.283-.215.604-.401.959-.401v0c.31 0 .555.26.532.57a48.039 48.039 0 01-.642 5.056c1.518.19 3.058.309 4.616.354a.64.64 0 00.657-.643v0c0-.355-.186-.676-.401-.959a1.647 1.647 0 01-.349-1.003c0-1.035 1.008-1.875 2.25-1.875 1.243 0 2.25.84 2.25 1.875 0 .369-.128.713-.349 1.003-.215.283-.4.604-.4.959v0c0 .333.277.599.61.58a48.1 48.1 0 005.427-.63 48.05 48.05 0 00.582-4.717.532.532 0 00-.533-.57v0c-.355 0-.676.186-.959.401-.29.221-.634.349-1.003.349-1.035 0-1.875-1.007-1.875-2.25s.84-2.25 1.875-2.25c.37 0 .713.128 1.003.349.283.215.604.401.959.401v0a.656.656 0 00.658-.663 48.422 48.422 0 00-.37-5.36c-1.886.342-3.81.574-5.766.689a.578.578 0 01-.61-.58v0z" />
+      </svg>
+    ),
+  },
+];
+
+export default function BottomNavBar() {
+  return (
+    /* 모바일에서만 표시 (md 이상 숨김) */
+    <nav
+      className="md:hidden fixed bottom-0 left-0 right-0 z-50
+                 bg-surface dark:bg-dark-surface2
+                 border-t border-surface-3 dark:border-dark-border
+                 shadow-bottom"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+    >
+      <div className="flex items-stretch h-nav-height">
+        {tabs.map(({ to, label, end, icon }) => (
+          <NavLink
+            key={to}
+            to={to}
+            end={end}
+            className={({ isActive }) =>
+              `flex-1 flex flex-col items-center justify-center gap-0.5 text-2xs font-medium
+               transition-colors duration-150
+               ${isActive
+                 ? 'text-primary dark:text-accent'
+                 : 'text-content-secondary dark:text-gray-500 hover:text-primary dark:hover:text-accent'
+               }`
+            }
+          >
+            {({ isActive }) => (
+              <>
+                {icon(isActive)}
+                <span>{label}</span>
+                {/* 활성 인디케이터 dot */}
+                {isActive && (
+                  <span className="absolute bottom-1 w-1 h-1 rounded-full bg-primary dark:bg-accent" />
+                )}
+              </>
+            )}
+          </NavLink>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -1,95 +1,70 @@
 import React from 'react';
 import { FaYoutube, FaInstagram, FaGithub } from 'react-icons/fa';
-import { SiTistory } from 'react-icons/si'; 
-import Link from '@mui/material/Link';
-import Typography from '@mui/material/Typography';
-import Container from '@mui/material/Container';
-import useMediaQuery from '@mui/material/useMediaQuery';
+import { SiTistory } from 'react-icons/si';
 
-function Copyright(props) {
-  return (
-    <Typography variant="body2" color="text.secondary" align="center" {...props}>
-      {'Copyright © '}
-      <Link color="inherit" href="https://mui.com/">
-        보리꼬리
-      </Link>{' '}
-      {new Date().getFullYear()}
-      {'.'}
-    </Typography>
-  );
-}
+/** 소셜 링크 아이콘 */
+const SocialLink = ({ href, children }) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="text-white/60 hover:text-accent transition-colors duration-150"
+  >
+    {children}
+  </a>
+);
 
+/** 데스크톱에서만 표시 (모바일은 BottomNavBar가 대체) */
 function Footer() {
-  const isMobile = useMediaQuery('(max-width: 768px)');
-
   return (
-    <footer className="bg-primary text-white pt-10 sm:mt-10">
-      <Container component="main" maxWidth="lg">
-        <div className="max-w-6xl m-auto flex flex-wrap justify-left">
-          
-          {/* 왼쪽 컬럼 */}
-          <div className={`p-5 ${isMobile ? 'w-full' : 'w-1/2 sm:w-4/12 md:w-3/12'}`}>
-            {/* 로고 */}
-            <div className="hover:text-accent flex items-center">
-              <a href="/" className="text-xl font-bold mx-auto">
-                <img
-                  className="h-16 w-auto"
-                  src="/images/bokko_pixel.svg"
-                  alt="보리꼬리 로고"
-                />
-              </a>
-            </div>
+    <footer className="hidden md:block bg-primary dark:bg-dark-surface2 text-white border-t border-primary-dark/30 dark:border-dark-border">
+      <div className="max-w-6xl mx-auto px-6 py-8">
+        <div className="flex flex-wrap gap-8 justify-between">
 
-            {/* 소셜 아이콘 */}
-            <div className="mt-4 flex items-center justify-center">
-              <span className="mx-3 hover:text-accent">
-                <a href="https://www.youtube.com/@jihoon2723">
-                  <FaYoutube size="24" />
-                </a>
-              </span>
-              <span className="mx-3 hover:text-accent">
-                <a href="https://www.instagram.com/zzzihooon/">
-                  <FaInstagram size="24" />
-                </a>
-              </span>
-              <span className="mx-3 hover:text-accent">
-                <a href="https://jihoon2723.tistory.com/">
-                  <SiTistory size="24" />
-                </a>
-              </span>
-              <span className="mx-3 hover:text-accent">
-                <a href="https://github.com/jihoonLeee">
-                  <FaGithub size="24" />
-                </a>
-              </span>
+          {/* 브랜드 + 소셜 */}
+          <div className="flex flex-col gap-4">
+            <a href="/" className="flex items-center gap-2">
+              <img
+                className="h-10 w-auto"
+                src="/images/bokko_pixel.svg"
+                alt="보리꼬리 로고"
+              />
+              <span className="font-headline font-bold text-lg">보리꼬리</span>
+            </a>
+            <div className="flex items-center gap-4">
+              <SocialLink href="https://www.youtube.com/@jihoon2723">
+                <FaYoutube size={20} />
+              </SocialLink>
+              <SocialLink href="https://www.instagram.com/zzzihooon/">
+                <FaInstagram size={20} />
+              </SocialLink>
+              <SocialLink href="https://jihoon2723.tistory.com/">
+                <SiTistory size={20} />
+              </SocialLink>
+              <SocialLink href="https://github.com/jihoonLeee">
+                <FaGithub size={20} />
+              </SocialLink>
             </div>
           </div>
 
-          {/* 중앙 컬럼 */}
-          <div className={`p-5 ${isMobile ? 'w-full' : 'w-1/2 sm:w-4/12 md:w-3/12'}`}>
-            <div className="mt-2">
-              <h3 className="text-xl mb-2 font-bold">Support</h3>
-              <ul className="list-none">
-                <li className="mb-2">
-                  <a
-                    href="mailto:ljh2723@gmail.com"
-                    className="hover:text-accent"
-                  >
-                    문의
-                  </a>
-                </li>
-              </ul>
-            </div>
+          {/* Support 링크 */}
+          <div>
+            <h3 className="text-sm font-semibold text-white/90 mb-3">Support</h3>
+            <ul className="space-y-2 text-sm text-white/60">
+              <li>
+                <a href="mailto:ljh2723@gmail.com" className="hover:text-accent transition-colors">
+                  문의하기
+                </a>
+              </li>
+            </ul>
           </div>
         </div>
 
-        {/* 하단 카피라이트 영역 */}
-        <div className="pt-4 border-t border-gray-500 text-sm flex flex-col items-center md:flex-row">
-          <div className="pt-2">
-            <Copyright />
-          </div>
+        {/* 카피라이트 */}
+        <div className="mt-8 pt-4 border-t border-white/10 text-center text-xs text-white/40">
+          Copyright © 보리꼬리 {new Date().getFullYear()}. All rights reserved.
         </div>
-      </Container>
+      </div>
     </footer>
   );
 }

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,130 +1,139 @@
-import React, { useState, useContext } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useContext } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../../contexts/AuthProvider';
-import axios from 'axios';
+import { useTheme } from '../../contexts/ThemeProvider';
+import axiosInstance from '../../api/axiosInstance';
 import UserAvatar from '../common/UserAvatar';
-import StyledButton from './StyledButton';
-import useMediaQuery from '@mui/material/useMediaQuery';
+
+/** 데스크톱 네비게이션 링크 */
+const NavItem = ({ to, children }) => (
+  <Link
+    to={to}
+    className="text-sm font-medium text-white/80 hover:text-white
+               transition-colors duration-150 px-1 py-0.5
+               hover:underline underline-offset-4 decoration-accent/70"
+  >
+    {children}
+  </Link>
+);
 
 export default function Header() {
   const { authenticated, userInfo } = useContext(AuthContext);
-  const isMobile = useMediaQuery('(max-width: 1024px)');
-  const logout = () => {
-    axios
-      .post('/logout', {}, { withCredentials: true })
+  const { isDark, toggleDark } = useTheme();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    axiosInstance
+      .post('/logout', {})
       .then(() => {
-        alert("로그아웃되었습니다.");
+        alert('로그아웃되었습니다.');
         window.location.reload();
       })
-      .catch((error) => console.log(error));
+      .catch(console.error);
   };
 
-  if (isMobile) {
-    // 모바일: 상단에 로고와 로그인/회원가입, 하단에 메뉴 영역 (메뉴는 줄바꿈됨)
-    return (
-      <header className="bg-primary text-white shadow-lg">
-        {/* Top Bar */}
-        <div className="flex items-center justify-between p-3">
-          {/* 왼쪽: 로고 */}
-          <Link to="/" className="flex items-center">
-            <span className="sr-only">보리꼬리</span>
-            <img
-              className="h-12 w-auto"
-              src={`${process.env.PUBLIC_URL}/images/bokko_pixel.svg`}
-              alt="보리꼬리 로고"
-            />
-          </Link>
-          {/* 오른쪽: 로그인/회원가입 또는 사용자 프로필 */}
-          <div className="flex items-center space-x-2">
-            {!authenticated ? (
-              <>
-                <StyledButton to="/login" className="text-white hover:text-accent text-xs px-2 py-1">
-                  로그인
-                </StyledButton>
-                <StyledButton to="/join" className="text-white hover:text-accent text-xs px-2 py-1">
-                  회원가입
-                </StyledButton>
-              </>
-            ) : (
-              <>
-                <UserAvatar userName={userInfo?.name} className="w-8 h-8" />
-                <StyledButton onClick={logout} className="text-white hover:text-accent text-xs px-2 py-1">
-                  로그아웃
-                </StyledButton>
-              </>
-            )}
-          </div>
-        </div>
-        {/* Bottom Bar: 네비게이션 메뉴 (자동 줄바꿈 적용) */}
-        <nav className="bg-primary px-3 py-2">
-          <div className="flex flex-wrap justify-center gap-2">
-            <StyledButton to="/board" className="text-white hover:text-accent text-xs px-2 py-1">
-              게시판
-            </StyledButton>
-            <StyledButton to="/map" className="text-white hover:text-accent text-xs px-2 py-1">
-              애견 맛집
-            </StyledButton>
-            {/* <StyledButton to="/chat" className="text-white hover:text-accent text-xs px-2 py-1">
-              실시간 소통
-            </StyledButton> */}
-            <StyledButton to="/games" className="text-white hover:text-accent text-xs px-2 py-1">
-              개임
-            </StyledButton>
-          </div>
+  return (
+    <header
+      className="sticky top-0 z-40
+                 bg-primary/95 dark:bg-dark-surface/95
+                 backdrop-blur-sm shadow-sm
+                 border-b border-primary-dark/30 dark:border-dark-border"
+    >
+      <div className="max-w-6xl mx-auto px-4 h-header-h flex items-center justify-between gap-4">
+
+        {/* ── 로고 ────────────────────────────────────── */}
+        <Link to="/" className="flex items-center gap-2 shrink-0">
+          <img
+            src={`${process.env.PUBLIC_URL}/images/bokko_pixel.svg`}
+            alt="보리꼬리 로고"
+            className="h-9 w-auto"
+          />
+          {/* 데스크톱에서만 서비스명 표시 */}
+          <span className="hidden md:block font-headline font-bold text-lg text-white tracking-tight">
+            보리꼬리
+          </span>
+        </Link>
+
+        {/* ── 데스크톱 네비게이션 (md 이상에서만 표시) ── */}
+        <nav className="hidden md:flex items-center gap-6">
+          <NavItem to="/">홈</NavItem>
+          <NavItem to="/board">게시판</NavItem>
+          <NavItem to="/chat">채팅</NavItem>
+          <NavItem to="/map">애견맛집</NavItem>
+          <NavItem to="/games">개임</NavItem>
+          <NavItem to="/dogBTI">DBTI</NavItem>
         </nav>
-      </header>
-    );
-  } else {
-    // 데스크톱: 메뉴가 늘어나면 자동 줄바꿈되도록 flex-wrap 적용
-    return (
-      <header className="bg-primary text-white shadow-lg">
-        <nav className="mx-auto flex flex-wrap items-center justify-between p-6 lg:px-8" aria-label="Global">
-          <div className="flex lg:flex-1">
-            <Link to="/" className="-m-1.5 p-1.5">
-              <span className="sr-only">보리꼬리</span>
-              <img
-                className="h-16 w-auto"
-                src={`${process.env.PUBLIC_URL}/images/bokko_pixel.svg`}
-                alt="보리꼬리 로고"
-              />
-            </Link>
-          </div>
-          <div className="flex flex-1 flex-wrap justify-center gap-4">
-            <StyledButton to="/board" className="text-white hover:text-accent">
-              게시판
-            </StyledButton>
-            <StyledButton to="/map" className="text-white hover:text-accent">
-              애견 맛집
-            </StyledButton>
-            {/* <StyledButton to="/chat" className="text-white hover:text-accent">
-              실시간 소통
-            </StyledButton> */}
-            <StyledButton to="/games" className="text-white hover:text-accent">
-              개임
-            </StyledButton>
-      
-          </div>
-          <div className="flex flex-1 flex-wrap justify-end gap-2 mt-2">
+
+        {/* ── 우측: 다크모드 토글 + 인증 버튼 ──────── */}
+        <div className="flex items-center gap-2 shrink-0">
+
+          {/* 다크모드 토글 */}
+          <button
+            onClick={toggleDark}
+            aria-label={isDark ? '라이트 모드로 전환' : '다크 모드로 전환'}
+            className="w-9 h-9 rounded-full flex items-center justify-center
+                       text-white/80 hover:text-white hover:bg-white/10
+                       transition-all duration-150"
+          >
+            {isDark ? (
+              /* 해 아이콘 - 라이트모드로 전환 */
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.166 17.834a.75.75 0 00-1.06 1.06l1.59 1.591a.75.75 0 001.061-1.06l-1.59-1.591zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.166 7.166a.75.75 0 001.06-1.06L5.634 4.515a.75.75 0 00-1.06 1.06l1.59 1.591z" />
+              </svg>
+            ) : (
+              /* 달 아이콘 - 다크모드로 전환 */
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                <path fillRule="evenodd" d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z" clipRule="evenodd" />
+              </svg>
+            )}
+          </button>
+
+          {/* 인증 버튼 (데스크톱) */}
+          <div className="hidden md:flex items-center gap-2">
             {!authenticated ? (
               <>
-                <StyledButton to="/login" className="text-white hover:text-accent">
+                <button
+                  onClick={() => navigate('/login')}
+                  className="text-sm font-medium text-white/80 hover:text-white transition-colors"
+                >
                   로그인
-                </StyledButton>
-                <StyledButton to="/join" className="text-white hover:text-accent">
+                </button>
+                <button
+                  onClick={() => navigate('/join')}
+                  className="text-sm font-semibold bg-white/15 hover:bg-white/25
+                             text-white px-3 py-1.5 rounded-lg transition-all duration-150"
+                >
                   회원가입
-                </StyledButton>
+                </button>
               </>
             ) : (
               <>
                 <UserAvatar userName={userInfo?.name} />
-                <StyledButton onClick={logout} className="text-white hover:text-accent">
+                <button
+                  onClick={handleLogout}
+                  className="text-sm font-medium text-white/70 hover:text-white transition-colors"
+                >
                   로그아웃
-                </StyledButton>
+                </button>
               </>
             )}
           </div>
-        </nav>
-      </header>
-    );
-  }
+
+          {/* 모바일: 아바타 또는 로그인 아이콘 */}
+          <div className="flex md:hidden items-center">
+            {authenticated ? (
+              <UserAvatar userName={userInfo?.name} size="sm" />
+            ) : (
+              <button
+                onClick={() => navigate('/login')}
+                className="text-sm font-medium text-white/80 hover:text-white"
+              >
+                로그인
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
 }

--- a/src/components/layout/StyledButton.jsx
+++ b/src/components/layout/StyledButton.jsx
@@ -1,13 +1,71 @@
-import { Link } from "react-router-dom";
+import React from 'react';
+import { Link } from 'react-router-dom';
 
-const StyledButton = ({ to, children, onClick, className = "" }) => (
-  <Link
-    to={to}
-    onClick={onClick}
-    className={`inline-flex items-center justify-center rounded-md text-sm font-semibold leading-6 ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 h-10 px-4 py-2 ${className}`}
-  >
-    {children}
-  </Link>
-);
+/**
+ * 공통 버튼 컴포넌트
+ * - to: React Router Link (내부 이동)
+ * - href: 일반 <a> 링크 (외부)
+ * - onClick: 버튼 클릭 핸들러
+ * - variant: 'primary'|'secondary'|'ghost'|'accent'|'danger' (기본: 'ghost')
+ * - size: 'sm'|'md'|'lg' (기본: 'md')
+ */
+
+const BASE =
+  'inline-flex items-center justify-center font-semibold rounded-lg transition-all duration-150 ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ' +
+  'disabled:opacity-50 disabled:pointer-events-none active:scale-95';
+
+const VARIANTS = {
+  primary:   'bg-primary text-white hover:bg-primary-dark',
+  secondary: 'border border-primary text-primary hover:bg-primary/10 dark:border-primary-light dark:text-primary-light',
+  ghost:     'text-primary hover:bg-primary/10 dark:text-primary-light',
+  accent:    'bg-accent text-white hover:bg-accent-dark',
+  danger:    'bg-red-500 text-white hover:bg-red-600',
+  white:     'text-white/80 hover:text-white hover:bg-white/10',
+};
+
+const SIZES = {
+  sm: 'text-xs px-3 py-1.5',
+  md: 'text-sm px-4 py-2',
+  lg: 'text-base px-5 py-2.5',
+};
+
+const StyledButton = ({
+  to,
+  href,
+  onClick,
+  children,
+  variant = 'ghost',
+  size = 'md',
+  className = '',
+  type = 'button',
+  disabled = false,
+  ...rest
+}) => {
+  const classes = `${BASE} ${VARIANTS[variant] ?? VARIANTS.ghost} ${SIZES[size]} ${className}`;
+
+  // React Router 내부 링크
+  if (to) {
+    return (
+      <Link to={to} className={classes} {...rest}>
+        {children}
+      </Link>
+    );
+  }
+  // 외부 링크
+  if (href) {
+    return (
+      <a href={href} className={classes} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+      </a>
+    );
+  }
+  // 버튼
+  return (
+    <button type={type} onClick={onClick} className={classes} disabled={disabled} {...rest}>
+      {children}
+    </button>
+  );
+};
 
 export default StyledButton;

--- a/src/components/user/JoinForm.jsx
+++ b/src/components/user/JoinForm.jsx
@@ -1,13 +1,34 @@
-import React, { useState, useRef } from 'react';
-import { TextField, Button, Grid, Link, Box } from '@mui/material';
-import Fade from '@mui/material/Fade';
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 
+/** 입력 필드 공통 컴포넌트 */
+const Field = ({ id, label, type = 'text', formik, autoComplete }) => (
+  <div className="flex flex-col gap-1.5">
+    <label htmlFor={id} className="text-sm font-medium text-content-primary dark:text-white">
+      {label}
+    </label>
+    <input
+      id={id}
+      name={id}
+      type={type}
+      autoComplete={autoComplete}
+      onChange={formik.handleChange}
+      onBlur={formik.handleBlur}
+      value={formik.values[id]}
+      className="input"
+      placeholder={label}
+    />
+    {formik.touched[id] && formik.errors[id] && (
+      <p className="text-xs text-red-500">{formik.errors[id]}</p>
+    )}
+  </div>
+);
+
 const JoinForm = ({ onSubmit, onVerify }) => {
   const [isVerified, setIsVerified] = useState(false);
-  const [email, setEmail] = useState('');
-  const nodeRef = useRef(null);
+  const [verifyLoading, setVerifyLoading] = useState(false);
 
   const formik = useFormik({
     initialValues: {
@@ -15,19 +36,19 @@ const JoinForm = ({ onSubmit, onVerify }) => {
       email: '',
       verificationNumber: '',
       password: '',
-      passwordCheck: ''
+      passwordCheck: '',
     },
     validationSchema: Yup.object({
-      name: Yup.string().required('필수 항목입니다.'),
-      email: Yup.string().email('이메일 형식이 틀렸습니다.').required('필수 항목입니다.'),
-      password: Yup.string().required('필수 항목입니다.'),
+      name:          Yup.string().required('닉네임을 입력해주세요.'),
+      email:         Yup.string().email('이메일 형식이 올바르지 않습니다.').required('이메일을 입력해주세요.'),
+      password:      Yup.string().min(6, '비밀번호는 6자 이상이어야 합니다.').required('비밀번호를 입력해주세요.'),
       passwordCheck: Yup.string()
         .oneOf([Yup.ref('password'), null], '비밀번호가 일치하지 않습니다.')
-        .required('필수 항목입니다.'),
+        .required('비밀번호 확인을 입력해주세요.'),
     }),
-    onSubmit: values => {
+    onSubmit: (values) => {
       if (!isVerified) {
-        alert("이메일 인증이 필요합니다.");
+        alert('이메일 인증이 필요합니다.');
         return;
       }
       onSubmit({
@@ -40,65 +61,108 @@ const JoinForm = ({ onSubmit, onVerify }) => {
   });
 
   const handleVerify = async () => {
-    const result = await onVerify(email);
-    if (result) {
-      setIsVerified(true);
+    if (!formik.values.email) {
+      formik.setFieldTouched('email', true);
+      return;
+    }
+    setVerifyLoading(true);
+    try {
+      const result = await onVerify(formik.values.email);
+      if (result) setIsVerified(true);
+    } finally {
+      setVerifyLoading(false);
     }
   };
 
   return (
-    <Box component="form" noValidate onSubmit={formik.handleSubmit} sx={{ mt: 3 }}>
-      <Grid container spacing={2}>
-        <Grid item xs={12}>
-          <TextField required fullWidth id="name" label="닉네임" name="name" autoComplete="family-name" onChange={formik.handleChange} value={formik.values.name} />
-          {formik.touched.name && formik.errors.name && <div style={{ color: 'red', textAlign: 'left', fontSize:'12px' }}>{formik.errors.name}</div>}
-        </Grid>
-        <Grid item xs={10}>
-          <TextField
-            required
-            fullWidth
-            id="email"
-            label="이메일"
-            name="email"
-            autoComplete="email"
-            value={formik.values.email}
-            onChange={(event) => {
-              formik.handleChange(event);
-              setEmail(event.target.value);
-            }}
-          />
-          {formik.touched.email && formik.errors.email && <div style={{ color: 'red', textAlign: 'left', fontSize:'12px' }}>{formik.errors.email}</div>}
-        </Grid>
-        <Grid item xs={2}>
-          <Button onClick={handleVerify} type="button" fullWidth variant="contained" sx={{ height: 55, mt: 0, ml: -1, backgroundColor: '#4caf50', '&:hover': { backgroundColor: '#357a38' } }}>
-            인증
-          </Button>
-        </Grid>
-        {isVerified && (
-          <Fade in={isVerified}>
-            <Grid item xs={12} ref={nodeRef}>
-              <TextField required fullWidth id="verificationNumber" label="인증번호" name="verificationNumber" onChange={formik.handleChange} value={formik.values.verificationNumber} />
-            </Grid>
-          </Fade>
-        )}
-        <Grid item xs={12}>
-          <TextField required fullWidth name="password" label="비밀번호" type="password" id="password" autoComplete="new-password" onChange={formik.handleChange} value={formik.values.password} />
-          {formik.touched.password && formik.errors.password && <div style={{ color: 'red', textAlign: 'left', fontSize:'12px' }}>{formik.errors.password}</div>}
-        </Grid>
-        <Grid item xs={12}>
-          <TextField required fullWidth name="passwordCheck" label="비밀번호 확인" type="password" id="passwordCheck" autoComplete="passwordCheck" onChange={formik.handleChange} value={formik.values.passwordCheck} />
-          {formik.touched.passwordCheck && formik.errors.passwordCheck && <div style={{ color: 'red', textAlign: 'left', fontSize:'12px' }}>{formik.errors.passwordCheck}</div>}
-        </Grid>
-      </Grid>
-      <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2, backgroundColor: '#4caf50', '&:hover': { backgroundColor: '#357a38' } }}>
-        회원가입
-      </Button>
-      <Grid container justifyContent="flex-end">
-        <Grid item>
-          <Link href="/login" variant="body2">이미 가입하셨나요?</Link>
-        </Grid>
-      </Grid>
-    </Box>
+    <div className="min-h-screen flex items-center justify-center
+                    bg-secondary dark:bg-dark-surface px-4 py-12">
+      <div className="w-full max-w-sm bg-surface dark:bg-dark-surface2
+                      rounded-2xl shadow-modal p-8
+                      border border-surface-3 dark:border-dark-border
+                      animate-fade-in">
+
+        {/* 로고 + 제목 */}
+        <div className="flex flex-col items-center mb-8">
+          <img className="h-16 w-auto mb-4" src="/images/borikkori_brown.svg" alt="보리꼬리" />
+          <h1 className="text-xl font-bold text-content-primary dark:text-white">회원가입</h1>
+          <p className="mt-1 text-sm text-content-secondary dark:text-gray-400">
+            함께 해요, 반려견 친구들! 🐾
+          </p>
+        </div>
+
+        {/* 폼 */}
+        <form noValidate onSubmit={formik.handleSubmit} className="flex flex-col gap-4">
+
+          <Field id="name" label="닉네임" formik={formik} autoComplete="family-name" />
+
+          {/* 이메일 + 인증 버튼 */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="email" className="text-sm font-medium text-content-primary dark:text-white">
+              이메일
+            </label>
+            <div className="flex gap-2">
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                value={formik.values.email}
+                className="input flex-1"
+                placeholder="이메일"
+                disabled={isVerified}
+              />
+              <button
+                type="button"
+                onClick={handleVerify}
+                disabled={isVerified || verifyLoading}
+                className="btn btn-accent shrink-0 text-xs px-3"
+              >
+                {isVerified ? '인증됨 ✓' : verifyLoading ? '전송중...' : '인증'}
+              </button>
+            </div>
+            {formik.touched.email && formik.errors.email && (
+              <p className="text-xs text-red-500">{formik.errors.email}</p>
+            )}
+          </div>
+
+          {/* 인증번호 입력 (이메일 인증 후 노출) */}
+          {isVerified && (
+            <div className="flex flex-col gap-1.5 animate-fade-in">
+              <label htmlFor="verificationNumber" className="text-sm font-medium text-content-primary dark:text-white">
+                인증번호
+              </label>
+              <input
+                id="verificationNumber"
+                name="verificationNumber"
+                type="text"
+                onChange={formik.handleChange}
+                value={formik.values.verificationNumber}
+                className="input"
+                placeholder="인증번호를 입력해주세요"
+              />
+            </div>
+          )}
+
+          <Field id="password"      label="비밀번호"      type="password" formik={formik} autoComplete="new-password" />
+          <Field id="passwordCheck" label="비밀번호 확인"  type="password" formik={formik} autoComplete="new-password" />
+
+          <button type="submit" className="btn btn-accent w-full mt-2">
+            회원가입
+          </button>
+        </form>
+
+        {/* 로그인 링크 */}
+        <p className="mt-6 text-center text-sm text-content-secondary dark:text-gray-400">
+          이미 계정이 있으신가요?{' '}
+          <Link to="/login" className="text-primary dark:text-primary-light font-semibold hover:underline">
+            로그인
+          </Link>
+        </p>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/user/LoginForm.jsx
+++ b/src/components/user/LoginForm.jsx
@@ -1,74 +1,90 @@
 import React from 'react';
-import Button from '@mui/material/Button';
-import CssBaseline from '@mui/material/CssBaseline';
-import TextField from '@mui/material/TextField';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
-import Link from '@mui/material/Link';
-import Grid from '@mui/material/Grid';
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
-import Container from '@mui/material/Container';
+import { Link } from 'react-router-dom';
+
+/** 입력 필드 공통 컴포넌트 */
+const InputField = ({ id, label, type = 'text', autoComplete, autoFocus }) => (
+  <div className="flex flex-col gap-1.5">
+    <label htmlFor={id} className="text-sm font-medium text-content-primary dark:text-white">
+      {label}
+    </label>
+    <input
+      id={id}
+      name={id}
+      type={type}
+      autoComplete={autoComplete}
+      autoFocus={autoFocus}
+      required
+      className="input"
+      placeholder={label}
+    />
+  </div>
+);
 
 const LoginForm = ({ handleSubmit }) => {
   return (
-    <Container component="main" maxWidth="xs">
-      <CssBaseline />
-      <Box
-        sx={{
-          marginTop: 8,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}
-      >
-        <img className="h-16 w-auto" src={`/images/borikkori_brown.svg`} alt="Borikkori Logo" />
-        <Typography component="h1" variant="h5">
-          로그인
-        </Typography>
-        <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
-          <TextField
-            margin="normal"
-            required
-            fullWidth
+    <div className="min-h-screen flex items-center justify-center
+                    bg-secondary dark:bg-dark-surface px-4 py-12">
+      <div className="w-full max-w-sm bg-surface dark:bg-dark-surface2
+                      rounded-2xl shadow-modal p-8
+                      border border-surface-3 dark:border-dark-border
+                      animate-fade-in">
+
+        {/* 로고 + 제목 */}
+        <div className="flex flex-col items-center mb-8">
+          <img
+            className="h-16 w-auto mb-4"
+            src="/images/borikkori_brown.svg"
+            alt="보리꼬리 로고"
+          />
+          <h1 className="text-xl font-bold text-content-primary dark:text-white">
+            로그인
+          </h1>
+          <p className="mt-1 text-sm text-content-secondary dark:text-gray-400">
+            보리꼬리에 오신 것을 환영해요 🐾
+          </p>
+        </div>
+
+        {/* 폼 */}
+        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
+          <InputField
             id="email"
             label="이메일"
-            name="email"
+            type="email"
             autoComplete="email"
             autoFocus
           />
-          <TextField
-            margin="normal"
-            required
-            fullWidth
-            name="password"
+          <InputField
+            id="password"
             label="비밀번호"
             type="password"
-            id="password"
             autoComplete="current-password"
           />
-          <FormControlLabel
-            control={<Checkbox value="remember" color="primary" />}
-            label="암호 저장하기"
-          />
-          <Button
-            type="submit"
-            fullWidth
-            variant="contained"
-            sx={{ mt: 3, mb: 2, backgroundColor: '#4caf50', '&:hover': { backgroundColor: '#357a38' } }}
-          >
+
+          {/* 암호 저장 체크박스 */}
+          <label className="flex items-center gap-2 text-sm text-content-secondary dark:text-gray-400 cursor-pointer">
+            <input
+              type="checkbox"
+              name="remember"
+              className="w-4 h-4 rounded border-surface-3 text-primary
+                         focus:ring-primary/50 focus:ring-2"
+            />
+            암호 저장하기
+          </label>
+
+          <button type="submit" className="btn btn-accent w-full mt-2">
             로그인
-          </Button>
-          <Grid container justifyContent="flex-end">
-            <Grid item>
-              <Link href="/#/join" variant="body2">
-                계정이 없으신가요?
-              </Link>
-            </Grid>
-          </Grid>
-        </Box>
-      </Box>
-    </Container>
+          </button>
+        </form>
+
+        {/* 회원가입 링크 */}
+        <p className="mt-6 text-center text-sm text-content-secondary dark:text-gray-400">
+          아직 계정이 없으신가요?{' '}
+          <Link to="/join" className="text-primary dark:text-primary-light font-semibold hover:underline">
+            회원가입
+          </Link>
+        </p>
+      </div>
+    </div>
   );
 };
 

--- a/src/containers/board/BoardListContainer.jsx
+++ b/src/containers/board/BoardListContainer.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import axiosInstance from '../../api/axiosInstance';
 import BoardList from '../../components/board/BoardList';
 
 const BoardListContainer = () => {
@@ -12,17 +12,15 @@ const BoardListContainer = () => {
   useEffect(() => {
     const fetchPosts = async () => {
       try {
-        const response = await axios.get('/post', {
-          params: { 
-            page, 
+        const response = await axiosInstance.get('/post', {
+          params: {
+            page,
             search: searchQuery,
-            category: categoryFilter 
+            category: categoryFilter,
           },
-          withCredentials: true,
         });
-        var postList = response.data.data;
+        setPosts(response.data.data || []);
         setTotalPosts(response.data.totalCount || 0);
-        setPosts(postList || []);
       } catch (error) {
         console.error('게시글을 불러오는 중 오류가 발생했습니다:', error);
       }
@@ -34,7 +32,7 @@ const BoardListContainer = () => {
   const handleSearch = () => {
     setPage(1);
   };
-  
+
   const handleCategoryFilterChange = (category) => {
     setCategoryFilter(category);
     setPage(1);

--- a/src/containers/board/BoardWriteContainer.jsx
+++ b/src/containers/board/BoardWriteContainer.jsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect, useContext, useCallback } from 'react';
-import { EditorState, AtomicBlockUtils, RichUtils, ContentState, SelectionState, ContentBlock } from 'draft-js';
+import { EditorState, AtomicBlockUtils, RichUtils, ContentState, SelectionState } from 'draft-js';
 import { useDropzone } from 'react-dropzone';
 import { useNavigate } from 'react-router-dom';
 import BoardWriteForm from '../../components/board/BoardWriteForm';
+import MediaBlock from '../../components/board/MediaBlock';
 import { initializePost, createPost, uploadFile, deletePost } from '../../api/boardApi';
 import { AuthContext } from '../../contexts/AuthProvider';
 import { getCategoryByKey } from '../../constants/boardCategory';
 import axios from 'axios';
+import axiosInstance from '../../api/axiosInstance';
 
 const BoardWriteContainer = () => {
   const [editorState, setEditorState] = useState(EditorState.createEmpty());
@@ -22,13 +24,6 @@ const BoardWriteContainer = () => {
 
   const onEditorChange = (newEditorState) => {
     setEditorState(newEditorState);
-    const contentState = newEditorState.getCurrentContent();
-    const selection = newEditorState.getSelection();
-    
-    // 선택 영역이 있는 경우에만 로그 출력
-    if (!selection.isCollapsed()) {
-      console.log('선택된 텍스트:', contentState.getBlockForKey(selection.getStartKey()).getText());
-    }
   };
 
   const addMediaToEditorState = (editorState, mediaUrl, mediaType) => {
@@ -72,60 +67,13 @@ const BoardWriteContainer = () => {
   const myBlockRenderer = (contentBlock) => {
     if (contentBlock.getType() === 'atomic') {
       return {
-        component: MediaComponent,
+        component: MediaBlock,
         props: { setSelection },
         editable: false,
       };
     }
     return null;
   };
-
-  const MediaComponent = React.memo((props) => {
-    const { block, contentState, setSelection } = props;
-    const entityKey = block.getEntityAt(0);
-    const videoRef = React.useRef(null);
-
-    const handleVideoFocus = useCallback(() => {
-      if (videoRef.current) {
-        videoRef.current.blur();
-      }
-    }, []);
-
-    const handleClick = useCallback((e) => {
-      e.stopPropagation();
-      const selection = SelectionState.create(block.key, 0, block.key, 1);
-      setSelection(selection);
-    }, [block.key, setSelection]);
-
-    const entity = entityKey ? contentState.getEntity(entityKey) : null;
-    const type = entity ? entity.getType() : null;
-
-    if (!entityKey) return null;
-
-    const { src } = entity.getData();
-
-    return (
-      <div
-        data-draft-js-block="true"
-        className="atomic-block"
-        style={{ userSelect: 'none' }}
-        onClick={handleClick}
-      >
-        {type === 'IMAGE' ? (
-          <img src={src} alt="uploaded" style={{ maxWidth: '100%' }} />
-        ) : type === 'VIDEO' ? (
-          <video
-            ref={videoRef}
-            src={src}
-            controls
-            style={{ maxWidth: '100%' }}
-            onFocus={handleVideoFocus}
-            tabIndex="-1"
-          />
-        ) : null}
-      </div>
-    );
-  });
 
   const handleTempSave = async () => {
     const contentStateJSON = JSON.stringify(
@@ -216,22 +164,16 @@ const BoardWriteContainer = () => {
 
   const handleImageUpload = async (file) => {
     if (!file) {
-      console.error('업로드할 파일이 없습니다.');
       return null;
     }
-    
-    console.log('파일 업로드 시작:', file.name);
-    
+
     try {
-      // 초기화된 postId가 없으면 생성
       if (!postId) {
         await initializePostId();
       }
-      
-      // 서버에 파일 업로드
+
       const uploadResult = await uploadFile({ file, postId });
-      console.log('서버 업로드 결과:', uploadResult);
-      
+
       if (uploadResult && uploadResult.fileUrl) {
         return uploadResult.fileUrl;
       } else {
@@ -329,11 +271,11 @@ const BoardWriteContainer = () => {
           } else {
             deletePost(data.postId)
               .then(() => window.location.reload())
-              .catch(console.log);
+              .catch(console.error);
           }
         }
       })
-      .catch(console.log);
+      .catch(console.error);
   }, [authenticated, navigate]);
   
 

--- a/src/containers/board/PostContainer.jsx
+++ b/src/containers/board/PostContainer.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import axios from 'axios';
+import axiosInstance from '../../api/axiosInstance';
 import PostView from '../../components/board/PostView';
 import { AuthContext } from '../../contexts/AuthProvider';
 
@@ -12,30 +12,32 @@ const PostContainer = () => {
   const [comments, setComments] = useState([]);
   const [totalComments, setTotalComments] = useState(0);
   const [page, setPage] = useState(1);
-
   const [prevPostId, setPrevPostId] = useState(null);
   const [nextPostId, setNextPostId] = useState(null);
+
+  const fetchComments = useCallback(async () => {
+    const response = await axiosInstance.get('/comment', {
+      params: { id: postId, page },
+    });
+    setComments(response.data.comments);
+    setTotalComments(response.data.totalCount);
+  }, [postId, page]);
 
   useEffect(() => {
     const fetchPostData = async () => {
       try {
-        const postResponse = await axios.get(`/post/${postId}`, { withCredentials: true });
+        const [postResponse, commentResponse, neighborResponse] = await Promise.all([
+          axiosInstance.get(`/post/${postId}`),
+          axiosInstance.get('/comment', { params: { id: postId, page } }),
+          axiosInstance.get(`/post/${postId}/neighbors`),
+        ]);
         setPosts(postResponse.data);
-        const commentResponse = await axios.get('/comment', {
-          params: { id: postId, page: page },
-          withCredentials: true,
-        });
-        setTotalComments(commentResponse.data.totalCount);
         setComments(commentResponse.data.comments);
-
-        // 이웃 게시글(이전글, 다음글) 데이터 가져오기
-        const neighborResponse = await axios.get(`/post/${postId}/neighbors`, { withCredentials: true });
-        const { prevPostId, nextPostId } = neighborResponse.data;
-        setPrevPostId(prevPostId);
-        setNextPostId(nextPostId);
-
+        setTotalComments(commentResponse.data.totalCount);
+        setPrevPostId(neighborResponse.data.prevPostId);
+        setNextPostId(neighborResponse.data.nextPostId);
       } catch (error) {
-        console.error("에러", error);
+        console.error('게시글 로딩 오류:', error);
       }
     };
 
@@ -48,17 +50,13 @@ const PostContainer = () => {
       return;
     }
     try {
-      const response = await axios.post(`/post/reaction`, {
-        postId : postId,
-        reactionType: "LIKE"
-      }, 
-        { withCredentials: true });
+      const response = await axiosInstance.post('/post/reaction', {
+        postId,
+        reactionType: 'LIKE',
+      });
       if (response.status === 200) {
         alert('따봉을 눌렀습니다!');
-        setPosts(prevPosts => ({
-          ...prevPosts,
-          likeCount: response.data.likeCount,
-        }));
+        setPosts((prev) => ({ ...prev, likeCount: response.data.likeCount }));
       }
     } catch (error) {
       console.error('따봉 처리 중 오류 발생', error);
@@ -72,13 +70,13 @@ const PostContainer = () => {
       return;
     }
     try {
-      const response = await axios.post(`/comment/like`, {
-        commentId : commentId,
-        reactionTyep : "LIKE"
-      }, { withCredentials: true });
+      const response = await axiosInstance.post('/comment/like', {
+        commentId,
+        reactionType: 'LIKE',
+      });
       if (response.status === 200) {
         alert('댓글에 따봉을 눌렀습니다!');
-        // Option: 전체 댓글 재조회 로직 추가 가능
+        await fetchComments();
       }
     } catch (error) {
       console.error('댓글 따봉 처리 중 오류 발생', error);
@@ -92,14 +90,14 @@ const PostContainer = () => {
       return;
     }
     try {
-      const response = await axios.post(
-        '/comment',
-        { postId: postId, email: userInfo.email, contents: content },
-        { withCredentials: true }
-      );
+      const response = await axiosInstance.post('/comment', {
+        postId,
+        email: userInfo.email,
+        contents: content,
+      });
       if (response.status === 201) {
         setContent('');
-        // Option: 전체 댓글 재조회 로직 추가 가능
+        await fetchComments();
       }
     } catch (error) {
       console.error('댓글 쓰기 실패!', error);

--- a/src/containers/user/UserJoinContainer.jsx
+++ b/src/containers/user/UserJoinContainer.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useEffect } from 'react';
-import { useNavigate } from "react-router-dom";
-import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { joinUser, sendEmailVerification } from '../../api/userApi';
 import JoinForm from '../../components/user/JoinForm';
 import BasicAlert from '../../components/common/BasicAlert';
 import { AuthContext } from '../../contexts/AuthProvider';
@@ -12,53 +12,36 @@ const UserJoinContainer = () => {
 
   useEffect(() => {
     if (authenticated) {
-      alert("접근할 수 없습니다.");
+      alert('접근할 수 없습니다.');
       navigate('/');
     }
   }, [authenticated, navigate]);
 
-  // 회원가입 API 호출
-  const joinUser = async (credentials) => {
+  const handleSubmit = async (formData) => {
     try {
-      const response = await axios.post(
-        `/user/join`,
-        credentials,
-        { withCredentials: true }
-      );
-      alert("회원가입이 완료되었습니다.");
-      navigate("/login");
-      return response.data;
+      await joinUser(formData);
+      alert('회원가입이 완료되었습니다.');
+      navigate('/login');
     } catch (error) {
       alert(`회원가입에 실패했습니다: ${error}`);
-      throw error;
     }
   };
 
-  // 이메일 인증 API 호출
-  const emailVerify = async (email) => {
+  const handleVerify = async (email) => {
     try {
-      const response = await axios.post(
-        `/user/sendEmail`,
-        { email },
-        { headers: { 'Content-Type': 'application/json' } }
-      );
-      if (response.status !== 200) throw new Error('Verification failed');
+      await sendEmailVerification(email);
       setShowAlert(true);
       return true;
     } catch (error) {
-      alert("인증메일 전송에 실패하였습니다.");
+      alert('인증메일 전송에 실패하였습니다.');
       return false;
     }
-  };
-
-  const handleSubmit = (formData) => {
-    joinUser(formData);
   };
 
   return (
     <div>
       {showAlert && <BasicAlert msg="이메일이 전송되었습니다." />}
-      <JoinForm onSubmit={handleSubmit} onVerify={emailVerify} />
+      <JoinForm onSubmit={handleSubmit} onVerify={handleVerify} />
     </div>
   );
 };

--- a/src/containers/user/UserLoginContainer.jsx
+++ b/src/containers/user/UserLoginContainer.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import { loginUser } from '../../api/userApi';
 import LoginForm from '../../components/user/LoginForm';
 import { AuthContext } from '../../contexts/AuthProvider';
 
@@ -10,35 +10,24 @@ const UserLoginContainer = () => {
 
   useEffect(() => {
     if (authenticated) {
-      alert("접근할 수 없습니다.");
+      alert('접근할 수 없습니다.');
       navigate('/');
     }
   }, [authenticated, navigate]);
 
-  // 로그인 API 호출
-  const loginUser = async (credentials) => {
-    try {
-      const response = await axios.post(
-        `/user/login`, 
-        credentials, 
-        { withCredentials: true }
-      );
-      navigate("/");
-      window.location.reload();
-      return response.data;
-    } catch (error) {
-      alert("로그인에 실패했습니다");
-      throw error;
-    }
-  };
-
   const handleSubmit = async (event) => {
     event.preventDefault();
     const data = new FormData(event.currentTarget);
-    await loginUser({
-      email: data.get('email'),
-      password: data.get('password'),
-    });
+    try {
+      await loginUser({
+        email: data.get('email'),
+        password: data.get('password'),
+      });
+      navigate('/');
+      window.location.reload();
+    } catch (error) {
+      alert('로그인에 실패했습니다');
+    }
   };
 
   return <LoginForm handleSubmit={handleSubmit} />;

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -1,5 +1,5 @@
-import React, { createContext, useState, useEffect } from 'react';
-import axios from 'axios';
+import React, { createContext, useState, useEffect, useMemo } from 'react';
+import axiosInstance from '../api/axiosInstance';
 import Spinner from '../components/common/Spinner';
 
 export const AuthContext = createContext();
@@ -7,13 +7,11 @@ export const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
     const [authenticated, setAuthenticated] = useState(null);
     const [userInfo, setUserInfo] = useState(null);
+
     useEffect(() => {
         const checkUserStatus = async () => {
             try {
-                const response = await axios.get(
-                    '/user/userInfo',
-                    { withCredentials: true }  
-                );
+                const response = await axiosInstance.get('/user/userInfo');
                 if (response.status === 200) {
                     setUserInfo(response.data);
                     setAuthenticated(true);
@@ -24,11 +22,18 @@ export const AuthProvider = ({ children }) => {
         };
         checkUserStatus();
     }, []);
+
+    const contextValue = useMemo(
+        () => ({ authenticated, setAuthenticated, userInfo }),
+        [authenticated, userInfo]
+    );
+
     if (authenticated === null) {
         return <Spinner />;
     }
+
     return (
-        <AuthContext.Provider value={{ authenticated, setAuthenticated, userInfo }}>
+        <AuthContext.Provider value={contextValue}>
             {children}
         </AuthContext.Provider>
     );

--- a/src/contexts/ThemeProvider.jsx
+++ b/src/contexts/ThemeProvider.jsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import useDarkMode from '../hooks/useDarkMode';
+
+const ThemeContext = createContext(null);
+
+/**
+ * 다크모드 Context Provider
+ * - isDark: 현재 다크모드 여부
+ * - toggleDark: 다크모드 토글 함수
+ */
+export const ThemeProvider = ({ children }) => {
+  const [isDark, toggleDark] = useDarkMode();
+
+  const value = useMemo(() => ({ isDark, toggleDark }), [isDark, toggleDark]);
+
+  return (
+    <ThemeContext.Provider value={value}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+/** 다크모드 상태 사용 훅 */
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used inside ThemeProvider');
+  return ctx;
+};
+
+export default ThemeProvider;

--- a/src/hooks/useDarkMode.js
+++ b/src/hooks/useDarkMode.js
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * 다크모드 토글 훅
+ * - localStorage에 선호도 저장
+ * - 초기값: 시스템 prefers-color-scheme 따름
+ * - <html> 엘리먼트에 'dark' 클래스 토글
+ */
+const useDarkMode = () => {
+  const [isDark, setIsDark] = useState(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) return stored === 'dark';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isDark) {
+      root.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      root.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [isDark]);
+
+  const toggleDark = () => setIsDark((prev) => !prev);
+
+  return [isDark, toggleDark];
+};
+
+export default useDarkMode;

--- a/src/index.css
+++ b/src/index.css
@@ -2,27 +2,115 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ── CSS 커스텀 프로퍼티 (테마 변수) ──────────────────────────────── */
+:root {
+  --color-primary:    #8B5E3C;
+  --color-secondary:  #FAF8F5;
+  --color-accent:     #4CAF50;
+  --color-surface:    #FFFFFF;
+  --color-surface2:   #F7F4F0;
+  --color-surface3:   #EDEBE7;
+  --color-text:       #1C1B1F;
+  --color-text-sub:   #49454F;
+  --color-border:     #E8E4DF;
+
+  --header-height: 60px;
+  --nav-height:    56px;
+}
+
+/* 다크모드 변수 오버라이드 */
+html.dark {
+  --color-surface:   #1A1A1A;
+  --color-surface2:  #252525;
+  --color-surface3:  #303030;
+  --color-text:      #E6E1E5;
+  --color-text-sub:  #CAC4D0;
+  --color-border:    #3A3A3A;
+}
+
+/* ── 기본 body 설정 ────────────────────────────────────────────── */
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: var(--color-secondary);
+  color: var(--color-text);
+  transition: background-color 0.2s, color 0.2s;
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
-}
-.btn {
-  @apply inline-block px-6 py-3 rounded-lg font-semibold text-center transition duration-300 cursor-pointer;
+html.dark body {
+  background-color: var(--color-surface);
 }
 
-.btn-primary {
-  @apply bg-primary text-white hover:underline;
+/* ── 스크롤바 (Chrome/Edge) ────────────────────────────────────── */
+::-webkit-scrollbar        { width: 6px; height: 6px; }
+::-webkit-scrollbar-track  { background: transparent; }
+::-webkit-scrollbar-thumb  { background: #CCC; border-radius: 3px; }
+html.dark ::-webkit-scrollbar-thumb { background: #555; }
+
+/* ── 공통 버튼 컴포넌트 클래스 ─────────────────────────────────── */
+@layer components {
+  .btn {
+    @apply inline-flex items-center justify-center
+           px-4 py-2 rounded-lg font-semibold text-sm
+           transition-all duration-200 cursor-pointer
+           focus-visible:outline-none focus-visible:ring-2
+           focus-visible:ring-primary focus-visible:ring-offset-2
+           disabled:opacity-50 disabled:pointer-events-none;
+  }
+  .btn-primary {
+    @apply bg-primary text-white hover:bg-primary-dark active:scale-95;
+  }
+  .btn-secondary {
+    @apply border border-primary text-primary
+           hover:bg-primary/10 active:scale-95
+           dark:border-primary-light dark:text-primary-light;
+  }
+  .btn-ghost {
+    @apply text-primary hover:bg-primary/10 active:scale-95
+           dark:text-primary-light;
+  }
+  .btn-accent {
+    @apply bg-accent text-white hover:bg-accent-dark active:scale-95;
+  }
+  .btn-danger {
+    @apply bg-red-500 text-white hover:bg-red-600 active:scale-95;
+  }
+  /* 카드 기본 스타일 */
+  .card {
+    @apply bg-surface dark:bg-dark-surface2
+           border border-surface-3 dark:border-dark-border
+           rounded-2xl shadow-card;
+  }
+  /* 입력 필드 기본 스타일 */
+  .input {
+    @apply w-full px-4 py-3 rounded-xl
+           bg-surface dark:bg-dark-surface3
+           border border-surface-3 dark:border-dark-border
+           text-content-primary dark:text-white
+           placeholder-content-disabled dark:placeholder-gray-500
+           focus:outline-none focus:ring-2 focus:ring-primary/50
+           transition duration-200;
+  }
 }
 
-.btn-secondary {
-  @apply bg-gray-500 text-white hover:bg-gray-600 hover:underline;
+/* ── Draft.js 에디터 필수 스타일 ───────────────────────────────── */
+.DraftEditor-root {
+  position: relative;
+}
+.DraftEditor-editorContainer {
+  position: relative;
+}
+.public-DraftEditor-content {
+  min-height: 300px;
+  padding: 12px;
+}
+/* 다크모드 Draft.js */
+html.dark .public-DraftEditor-content {
+  color: #E6E1E5;
+}
+html.dark .public-DraftEditorPlaceholder-root {
+  color: #9E9E9E;
 }

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,179 +1,266 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import axiosInstance from '../../api/axiosInstance';
 import { Link } from 'react-router-dom';
+import { getCategoryInfo } from '../../utils/categoryUtils';
 
-const SkeletonLoader = () => (
-  <div className="animate-pulse">
-    <div className="h-48 bg-gray-200 rounded-lg mb-4"></div>
-    <div className="space-y-3">
-      <div className="h-6 bg-gray-200 rounded w-3/4"></div>
-      <div className="h-4 bg-gray-200 rounded w-1/2"></div>
-      <div className="h-4 bg-gray-200 rounded w-2/3"></div>
-    </div>
+/* ── 스켈레톤 로더 ──────────────────────────────────────────── */
+const PostSkeleton = () => (
+  <div className="animate-pulse flex flex-col gap-2 py-3 border-b border-surface-3 dark:border-dark-border last:border-0">
+    <div className="h-4 bg-surface-3 dark:bg-dark-surface3 rounded w-4/5" />
+    <div className="h-3 bg-surface-3 dark:bg-dark-surface3 rounded w-1/3" />
   </div>
 );
 
-const Card = ({ children, className = '' }) => (
-  <div className={`card bg-white p-6 ${className}`}>
-    {children}
+const MbtiSkeleton = () => (
+  <div className="animate-pulse flex flex-col items-center gap-2">
+    <div className="w-16 h-16 bg-surface-3 dark:bg-dark-surface3 rounded-full" />
+    <div className="h-3 bg-surface-3 dark:bg-dark-surface3 rounded w-12" />
   </div>
 );
 
+/* ── 빠른 메뉴 아이템 ──────────────────────────────────────── */
+const quickMenus = [
+  { to: '/dogBTI', emoji: '🐶', label: '개BTI 테스트' },
+  { to: '/board',  emoji: '📋', label: '게시판' },
+  { to: '/map',    emoji: '🗺️', label: '애견맛집' },
+  { to: '/chat',   emoji: '💬', label: '채팅' },
+  { to: '/games',  emoji: '🎮', label: '개임' },
+];
+
+/* ── 게시글 한 줄 컴포넌트 ─────────────────────────────────── */
+const PostRow = ({ post }) => {
+  const { name: catName, color } = getCategoryInfo(post.categoryType);
+  return (
+    <Link
+      to={`/post/${post.postId}`}
+      className="flex items-center gap-3 py-3
+                 border-b border-surface-3 dark:border-dark-border last:border-0
+                 hover:bg-surface-2 dark:hover:bg-dark-surface3
+                 -mx-4 px-4 rounded-lg transition-colors duration-150"
+    >
+      {/* 카테고리 뱃지 */}
+      <span
+        className="shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full"
+        style={{ color, backgroundColor: `${color}18` }}
+      >
+        {catName}
+      </span>
+      {/* 제목 */}
+      <span className="flex-1 text-sm font-medium text-content-primary dark:text-white truncate">
+        {post.title}
+      </span>
+      {/* 좋아요 */}
+      {post.likeCount > 0 && (
+        <span className="shrink-0 text-xs text-red-400 font-medium">
+          ♥ {post.likeCount}
+        </span>
+      )}
+    </Link>
+  );
+};
+
+/* ── 메인 홈 컴포넌트 ─────────────────────────────────────── */
 export default function DogHouse() {
-  const [mbtiResults, setMbtiResults] = useState([]);
-  const [latestPosts, setLatestPosts] = useState([]);
+  const [mbtiResults, setMbtiResults]   = useState([]);
+  const [latestPosts, setLatestPosts]   = useState([]);
   const [popularPosts, setPopularPosts] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading]       = useState(true);
 
   useEffect(() => {
     const fetchData = async () => {
       setIsLoading(true);
       try {
-        const [mbtiResponse, latestResponse, popularResponse] = await Promise.all([
-          axios.get('/mbti', { withCredentials: true }),
-          axios.get('/post/latest', { withCredentials: true }),
-          axios.get('/post/popular', { withCredentials: true })
+        const [mbtiRes, latestRes, popularRes] = await Promise.all([
+          axiosInstance.get('/mbti'),
+          axiosInstance.get('/post/latest'),
+          axiosInstance.get('/post/popular'),
         ]);
-
-        setMbtiResults(Array.isArray(mbtiResponse.data) ? mbtiResponse.data : []);
-        setLatestPosts(Array.isArray(latestResponse.data) ? latestResponse.data : []);
-        setPopularPosts(Array.isArray(popularResponse.data) ? popularResponse.data : []);
-      } catch (error) {
-        console.error('데이터 로딩 중 에러 발생:', error);
+        setMbtiResults(Array.isArray(mbtiRes.data)     ? mbtiRes.data     : []);
+        setLatestPosts(Array.isArray(latestRes.data)   ? latestRes.data   : []);
+        setPopularPosts(Array.isArray(popularRes.data) ? popularRes.data  : []);
+      } catch (err) {
+        console.error('홈 데이터 로딩 실패:', err);
       } finally {
         setIsLoading(false);
       }
     };
-
     fetchData();
   }, []);
 
-  if (isLoading) {
-    return (
-      <main className="min-h-screen bg-secondary py-12">
-        <div className="container mx-auto px-4">
-          <div className="grid gap-8">
-            <Card><SkeletonLoader /></Card>
-            <div className="grid md:grid-cols-3 gap-8">
-              <Card><SkeletonLoader /></Card>
-              <Card className="md:col-span-2"><SkeletonLoader /></Card>
+  return (
+    <main className="min-h-screen bg-secondary dark:bg-dark-surface transition-colors duration-200">
+
+      {/* ── Hero 섹션 ────────────────────────────────── */}
+      <section className="relative bg-gradient-to-br from-primary/10 via-secondary to-secondary
+                          dark:from-dark-surface2 dark:via-dark-surface dark:to-dark-surface
+                          py-12 md:py-20 overflow-hidden">
+        {/* 배경 장식 */}
+        <div className="absolute top-0 right-0 w-64 h-64 bg-accent/5 rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl" />
+        <div className="absolute bottom-0 left-0 w-48 h-48 bg-primary/5 rounded-full translate-y-1/2 -translate-x-1/2 blur-2xl" />
+
+        <div className="relative max-w-6xl mx-auto px-4 flex flex-col md:flex-row items-center gap-8">
+          {/* 텍스트 */}
+          <div className="flex-1 text-center md:text-left animate-fade-in">
+            <h1 className="text-3xl md:text-5xl font-bold font-headline text-content-primary dark:text-white leading-tight">
+              우리 강아지와 함께하는<br />
+              <span className="text-primary dark:text-primary-light">보리꼬리</span>
+            </h1>
+            <p className="mt-4 text-base md:text-lg text-content-secondary dark:text-gray-400 leading-relaxed">
+              개BTI 테스트부터 애견 맛집까지,<br className="hidden md:block" />
+              반려견과 함께하는 모든 것을 담았어요 🐾
+            </p>
+            <div className="mt-8 flex flex-wrap justify-center md:justify-start gap-3">
+              <Link to="/dogBTI" className="btn btn-primary shadow-float">
+                개BTI 테스트 하기
+              </Link>
+              <Link to="/board" className="btn btn-secondary">
+                게시판 보기
+              </Link>
             </div>
           </div>
-        </div>
-      </main>
-    );
-  }
 
-  return (
-    <main className="min-h-screen bg-secondary">
-      {/* Hero Section */}
-      <section className="bg-gradient-to-b from-primary/10 to-secondary py-20">
-        <div className="container mx-auto px-4">
-          <div className="text-center max-w-3xl mx-auto">
-            <h1 className="text-4xl md:text-5xl font-bold text-text mb-6">
-              Welcome to <span className="text-primary">보리꼬리</span>
-            </h1>
-            {/* <p className="text-lg md:text-xl text-text-light mb-12 leading-relaxed">
-              우리 강아지가 사람이라면? 검증되지 않은 개BTI 테스트!<br/>
-              우리 강아지랑 어딜 가면 좋을까? 반려견 관련 주변 장소 추천!<br/>
-              그리고 5천만 반려인들과 소통하세요~
-            </p> */}
-          <div className="flex flex-col sm:flex-row justify-center gap-4">
-              <Link to="/dogBTI" className="btn btn-primary">
-                개BTI 테스트 하러가기
-              </Link>
-              
-              <Link 
-                to="/map" className="btn btn-primary">
-                개와 함께! 주변 장소 보러가기
-              </Link>
-            </div>
-
-            <div className="mt-12">
-              <img
-                src={`${process.env.PUBLIC_URL}/images/borikkori_4cut.png`}
-                alt="브로콜리 캐릭터 4컷 만화"
-                className="mx-auto w-full max-w-md"
-              />
-            </div>
+          {/* 캐릭터 이미지 */}
+          <div className="shrink-0 animate-slide-up">
+            <img
+              src={`${process.env.PUBLIC_URL}/images/borikkori_4cut.png`}
+              alt="보리꼬리 캐릭터"
+              className="w-48 md:w-72 mx-auto drop-shadow-lg"
+            />
           </div>
         </div>
       </section>
 
-      {/* Content Sections */}
-      <section className="py-16">
-        <div className="container mx-auto px-4">
-          <div className="grid md:grid-cols-3 gap-8">
-            {/* MBTI Section */}
-            <Card>
-              <h2 className="text-2xl font-bold text-text mb-6">
-                개비티아이 TOP 3
-              </h2>
-              <div className="grid grid-cols-3 gap-4">
-                {mbtiResults.map((result, index) => (
-                  <div key={index} className="text-center">
-                    <div className="relative pb-[100%] mb-3">
+      {/* ── 빠른 메뉴 (당근마켓 스타일) ───────────────── */}
+      <section className="max-w-6xl mx-auto px-4 py-8">
+        <div className="flex justify-around md:justify-start md:gap-8">
+          {quickMenus.map(({ to, emoji, label }) => (
+            <Link
+              key={to}
+              to={to}
+              className="flex flex-col items-center gap-2 group"
+            >
+              <div className="w-14 h-14 rounded-2xl bg-surface dark:bg-dark-surface2
+                              flex items-center justify-center text-2xl shadow-card
+                              group-hover:shadow-float group-hover:-translate-y-0.5
+                              transition-all duration-200 border border-surface-3 dark:border-dark-border">
+                {emoji}
+              </div>
+              <span className="text-xs font-medium text-content-secondary dark:text-gray-400
+                               group-hover:text-primary dark:group-hover:text-primary-light transition-colors">
+                {label}
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* ── 컨텐츠 그리드 ────────────────────────────── */}
+      <section className="max-w-6xl mx-auto px-4 pb-12">
+        <div className="grid md:grid-cols-3 gap-4 md:gap-6">
+
+          {/* 개BTI TOP 3 */}
+          <div className="bg-surface dark:bg-dark-surface2 rounded-2xl shadow-card p-5
+                          border border-surface-3 dark:border-dark-border">
+            <h2 className="text-base font-bold text-content-primary dark:text-white mb-4">
+              🏆 개BTI TOP 3
+            </h2>
+            {isLoading ? (
+              <div className="flex justify-around">
+                {[0, 1, 2].map((i) => <MbtiSkeleton key={i} />)}
+              </div>
+            ) : mbtiResults.length === 0 ? (
+              <p className="text-sm text-content-secondary dark:text-gray-500 text-center py-4">
+                데이터가 없습니다
+              </p>
+            ) : (
+              <div className="flex justify-around">
+                {mbtiResults.slice(0, 3).map((result, idx) => (
+                  <div key={idx} className="flex flex-col items-center gap-1.5">
+                    <div className="relative">
                       <img
-                        alt={`MBTI ${result.type}`}
                         src={`${process.env.PUBLIC_URL}/images/face_results/${result.type}.png`}
-                        className="absolute inset-0 w-full h-full object-contain"
+                        alt={result.type}
+                        className="w-14 h-14 object-contain rounded-full bg-surface-2 dark:bg-dark-surface3 p-1"
                       />
+                      {/* 순위 뱃지 */}
+                      {idx === 0 && (
+                        <span className="absolute -top-1 -right-1 text-xs">👑</span>
+                      )}
                     </div>
-                    <p className="font-medium text-text">
+                    <span className="text-xs font-bold text-primary dark:text-primary-light">
                       {result.type}
-                    </p>
-                    <p className="text-sm text-text-light">
+                    </span>
+                    <span className="text-2xs text-content-secondary dark:text-gray-500">
                       {result.count}명
-                    </p>
+                    </span>
                   </div>
                 ))}
               </div>
-            </Card>
-
-            {/* Latest Posts */}
-            <Card className="md:col-span-2">
-              <div className="flex justify-between items-center mb-6">
-                <h2 className="text-2xl font-bold text-text">최신 게시글</h2>
-                <Link to="/board" className="text-primary hover:text-primary-dark">
-                  더보기 →
-                </Link>
-              </div>
-              <div className="grid sm:grid-cols-2 gap-6">
-                {latestPosts.slice(0, 4).map((post, index) => (
-                  <article key={index} className="group">
-                    <h3 className="text-lg font-bold text-text group-hover:text-primary transition-colors">
-                      {post.title}
-                    </h3>
-                    <p className="mt-2 text-text-light line-clamp-2">
-                      {post.excerpt}
-                    </p>
-                  </article>
-                ))}
-              </div>
-            </Card>
+            )}
+            <Link
+              to="/dogBTI"
+              className="mt-4 block text-center text-xs text-primary dark:text-primary-light
+                         font-medium hover:underline"
+            >
+              테스트 하러가기 →
+            </Link>
           </div>
 
-          {/* Popular Posts */}
-          <Card className="mt-8">
-            <div className="flex justify-between items-center mb-6">
-              <h2 className="text-2xl font-bold text-text">인기 게시글</h2>
-              <Link to="/board" className="text-primary hover:text-primary-dark">
+          {/* 최신 게시글 */}
+          <div className="md:col-span-2 bg-surface dark:bg-dark-surface2 rounded-2xl shadow-card p-5
+                          border border-surface-3 dark:border-dark-border">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-base font-bold text-content-primary dark:text-white">
+                🆕 최신 게시글
+              </h2>
+              <Link to="/board" className="text-xs text-primary dark:text-primary-light font-medium hover:underline">
                 더보기 →
               </Link>
             </div>
-            <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
-              {popularPosts.slice(0, 6).map((post, index) => (
-                <article key={index} className="group">
-                  <h3 className="text-lg font-bold text-text group-hover:text-primary transition-colors">
-                    {post.title}
-                  </h3>
-                  <p className="mt-2 text-text-light line-clamp-2">
-                    {post.excerpt}
-                  </p>
-                </article>
-              ))}
+            {isLoading ? (
+              <div className="divide-y divide-surface-3 dark:divide-dark-border">
+                {[0, 1, 2, 3, 4].map((i) => <PostSkeleton key={i} />)}
+              </div>
+            ) : latestPosts.length === 0 ? (
+              <p className="text-sm text-content-secondary dark:text-gray-500 text-center py-8">
+                게시글이 없습니다
+              </p>
+            ) : (
+              <div>
+                {latestPosts.slice(0, 6).map((post, idx) => (
+                  <PostRow key={idx} post={post} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 인기 게시글 */}
+          <div className="md:col-span-3 bg-surface dark:bg-dark-surface2 rounded-2xl shadow-card p-5
+                          border border-surface-3 dark:border-dark-border">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-base font-bold text-content-primary dark:text-white">
+                🔥 인기 게시글
+              </h2>
+              <Link to="/board" className="text-xs text-primary dark:text-primary-light font-medium hover:underline">
+                더보기 →
+              </Link>
             </div>
-          </Card>
+            {isLoading ? (
+              <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-x-6">
+                {[0, 1, 2].map((i) => <PostSkeleton key={i} />)}
+              </div>
+            ) : popularPosts.length === 0 ? (
+              <p className="text-sm text-content-secondary dark:text-gray-500 text-center py-6">
+                인기 게시글이 없습니다
+              </p>
+            ) : (
+              <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-x-6">
+                {popularPosts.slice(0, 6).map((post, idx) => (
+                  <PostRow key={idx} post={post} />
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </section>
     </main>

--- a/src/queries/dbti/useDogMbtiQuery.js
+++ b/src/queries/dbti/useDogMbtiQuery.js
@@ -1,12 +1,8 @@
-import { useQuery } from "react-query";
-import axios from "axios";
+import { useQuery } from 'react-query';
+import axiosInstance from '../../api/axiosInstance';
 
 const fetchMbtiResult = async (result) => {
-  const response = await axios.post(
-    '/mbti',
-    { result: result.toUpperCase() },
-    { withCredentials: true }
-  );
+  const response = await axiosInstance.post('/mbti', { result: result.toUpperCase() });
   return response.data;
 };
 

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -7,12 +7,12 @@ const DogHouse = lazy(() => import('../pages/home/Home'));
 const Join = lazy(() => import('../pages/user/JoinPage'));
 const Login = lazy(() => import('../pages/user/LoginPage'));
 const BoardWrite = lazy(() => import('../pages/board/BoardWritePage'));
-const GameList = lazy(() => import('../pages/game/GameList'));
-const Game = lazy(() => import('../pages/game/Game'));
+const GameList = lazy(() => import('../pages/Game/GameList'));
+const Game = lazy(() => import('../pages/Game/Game'));
 const Post = lazy(() => import('../pages/board/PostPage'));
-const ChatRoom = lazy(() => import('../pages/chat/ChatRoom'));
-const ChatRoomList = lazy(() => import('../pages/chat/ChatRoomList'));
-const ChatLayout = lazy(() => import('../pages/chat/ChatLayout'));
+const ChatRoom = lazy(() => import('../pages/Chat/ChatRoom'));
+const ChatRoomList = lazy(() => import('../pages/Chat/ChatRoomList'));
+const ChatLayout = lazy(() => import('../pages/Chat/ChatLayout'));
 const KakaoMap = lazy(() => import('../pages/map/KakaoMapPage'));
 
 const routes = [

--- a/src/styles/BoardWrite.css
+++ b/src/styles/BoardWrite.css
@@ -1,30 +1,41 @@
+/* ── Draft.js 에디터 레이아웃 ───────────────────────────────── */
 .postEditor {
     width: 100%;
-    height: 500px;
+    min-height: 400px;
     overflow: auto;
-    margin-bottom: 20px;
+    margin-bottom: 16px;
     -webkit-overflow-scrolling: touch; /* iOS 스크롤 개선 */
-    touch-action: manipulation; /* 모바일 터치 동작 최적화 */
+    touch-action: manipulation;        /* 모바일 터치 최적화 */
 }
 
+/* 제목 입력 - BoardWriteForm에서 Tailwind로 대체됨 (하위 호환) */
 .postTitle {
     width: 100%;
-    padding: 10px;
-    border: 1px solid black;
-    -webkit-appearance: none; /* iOS 기본 스타일 제거 */
+    padding: 12px 16px;
+    font-size: 16px; /* iOS 자동 확대 방지 */
+    border: 1px solid var(--color-border, #E8E4DF);
+    border-radius: 12px;
+    background-color: var(--color-surface, #fff);
+    -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
+    transition: border-color 0.2s, box-shadow 0.2s;
 }
 
-/* 모바일 환경에서의 에디터 스타일 */
-@media (max-width: 768px) {
-    .postEditor {
-        height: 400px;
-        font-size: 16px; /* iOS에서 자동 확대 방지 */
-    }
-    
-    .postTitle {
-        font-size: 16px; /* iOS에서 자동 확대 방지 */
-    }
+.postTitle:focus {
+    outline: none;
+    border-color: #8B5E3C;
+    box-shadow: 0 0 0 3px rgba(139, 94, 60, 0.15);
 }
-  
+
+/* 다크모드 */
+html.dark .postTitle {
+    background-color: var(--color-surface3, #303030);
+    border-color: var(--color-border, #3A3A3A);
+    color: #E6E1E5;
+}
+
+/* 모바일 */
+@media (max-width: 768px) {
+    .postEditor { min-height: 300px; }
+}

--- a/src/utils/categoryUtils.js
+++ b/src/utils/categoryUtils.js
@@ -1,0 +1,42 @@
+import { getCategoryByKey } from '../constants/boardCategory';
+
+const CATEGORY_COLORS = {
+  NOTICE: '#f44336',
+  FREE: '#2196f3',
+  INFO: '#ff9800',
+  FUNNY: '#9c27b0',
+  BEGINNER: '#009688',
+  DEFAULT: '#4caf50',
+};
+
+/**
+ * 카테고리 키로 표시 정보(이름, 색상, 공지 여부)를 반환합니다.
+ * @param {string} categoryKey
+ * @returns {{ name: string, color: string, isNotice: boolean }}
+ */
+export const getCategoryInfo = (categoryKey) => {
+  if (!categoryKey) return { name: '미분류', color: '#999', isNotice: false };
+
+  const categoryInfo = getCategoryByKey(categoryKey);
+  if (!categoryInfo) return { name: '미분류', color: '#999', isNotice: false };
+
+  let color = CATEGORY_COLORS.DEFAULT;
+
+  if (categoryInfo.isNotice) {
+    color = CATEGORY_COLORS.NOTICE;
+  } else if (categoryKey.includes('FREE')) {
+    color = CATEGORY_COLORS.FREE;
+  } else if (categoryKey.includes('INFO')) {
+    color = CATEGORY_COLORS.INFO;
+  } else if (categoryKey.includes('FUNNY')) {
+    color = CATEGORY_COLORS.FUNNY;
+  } else if (categoryKey.includes('BEGINNER')) {
+    color = CATEGORY_COLORS.BEGINNER;
+  }
+
+  return {
+    name: categoryInfo.name,
+    color,
+    isNotice: !!categoryInfo.isNotice,
+  };
+};

--- a/src/utils/sanitize.js
+++ b/src/utils/sanitize.js
@@ -1,0 +1,19 @@
+/**
+ * HTML 콘텐츠에서 XSS 위험 요소를 제거합니다.
+ * TODO: dompurify 패키지 설치 후 아래와 같이 교체하면 더 안전합니다.
+ *   import DOMPurify from 'dompurify';
+ *   export const sanitizeHtml = (html) => DOMPurify.sanitize(html);
+ *   npm install dompurify
+ */
+
+const DANGEROUS_TAGS = /<script[\s\S]*?>[\s\S]*?<\/script>/gi;
+const DANGEROUS_ATTRS = /\son\w+\s*=\s*(['"]?)[\s\S]*?\1/gi;
+const JAVASCRIPT_HREF = /href\s*=\s*(['"]?)\s*javascript:/gi;
+
+export const sanitizeHtml = (html) => {
+  if (!html || typeof html !== 'string') return '';
+  return html
+    .replace(DANGEROUS_TAGS, '')
+    .replace(DANGEROUS_ATTRS, '')
+    .replace(JAVASCRIPT_HREF, 'href=$1#');
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,27 +1,96 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   important: true,
+  darkMode: 'class', // 다크모드: <html class="dark"> 토글 방식
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     extend: {
       colors: {
-        // 로고와 어울리는 갈색(primary), 크림색(secondary), 포인트 초록(accent)
-        primary: '#8B5E3C',
-        secondary: '#FAF8F5',
-        accent: '#4caf50',
+        // ── Primary (따뜻한 갈색 - 로고 기반) ──────────────────
+        primary: {
+          DEFAULT: '#8B5E3C',
+          dark:    '#6F4B30',
+          light:   '#A57850',
+        },
+        // ── Secondary (크림 배경) ────────────────────────────
+        secondary: {
+          DEFAULT: '#FAF8F5',
+          dark:    '#F0ECE6',
+        },
+        // ── Accent (포인트 초록 - 픽셀아트 강아지 색상) ─────────
+        accent: {
+          DEFAULT: '#4CAF50',
+          dark:    '#388E3C',
+          light:   '#66BB6A',
+        },
+        // ── Surface (카드/배경 계층) ─────────────────────────
+        surface: {
+          DEFAULT: '#FFFFFF',
+          2:       '#F7F4F0',
+          3:       '#EDEBE7',
+        },
+        // ── Dark Surface (다크모드 전용) ─────────────────────
+        dark: {
+          surface:  '#1A1A1A',
+          surface2: '#252525',
+          surface3: '#303030',
+          border:   '#3A3A3A',
+        },
+        // ── 텍스트 ─────────────────────────────────────────
+        content: {
+          primary:   '#1C1B1F',
+          secondary: '#49454F',
+          disabled:  '#9E9E9E',
+        },
       },
+
+      // ── 타이포그래피 ────────────────────────────────────────
+      fontFamily: {
+        sans:     ['Noto Sans KR', 'sans-serif'],
+        headline: ['Poppins', 'sans-serif'],
+      },
+
+      // ── 그림자 계층 ────────────────────────────────────────
+      boxShadow: {
+        card:   '0 1px 4px rgba(0,0,0,0.08), 0 2px 8px rgba(0,0,0,0.04)',
+        modal:  '0 8px 32px rgba(0,0,0,0.16)',
+        float:  '0 4px 16px rgba(139,94,60,0.16)',
+        bottom: '0 -1px 8px rgba(0,0,0,0.08)',
+      },
+
+      // ── Border Radius ──────────────────────────────────────
+      borderRadius: {
+        '4xl': '2rem',
+        pill:  '9999px',
+      },
+
+      // ── 애니메이션 ─────────────────────────────────────────
       animation: {
-        spin: 'spin 1s linear infinite',
+        spin:        'spin 1s linear infinite',
+        'fade-in':   'fadeIn 0.2s ease-out',
+        'slide-up':  'slideUp 0.3s ease-out',
+        'pulse-slow':'pulse 2s cubic-bezier(0.4,0,0.6,1) infinite',
       },
       keyframes: {
         spin: {
-          '0%': { transform: 'rotate(0deg)' },
+          '0%':   { transform: 'rotate(0deg)' },
           '100%': { transform: 'rotate(360deg)' },
         },
+        fadeIn: {
+          '0%':   { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+        slideUp: {
+          '0%':   { opacity: '0', transform: 'translateY(8px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
       },
-      fontFamily: {
-        sans: ['Noto Sans KR', 'sans-serif'], // 기본 폰트로 지정
-        headline: ['Poppins', 'sans-serif'],   // 헤드라인 전용
+
+      // ── 여백/간격 ──────────────────────────────────────────
+      spacing: {
+        safe:          'env(safe-area-inset-bottom)', // iOS 홈버튼 안전 여백
+        'nav-height':  '56px',                        // 하단 탭바 높이
+        'header-h':    '60px',                        // 상단 헤더 높이
       },
     },
   },


### PR DESCRIPTION
- MUI Material / MUI Joy / styled-components 전체 제거, Tailwind CSS 전용으로 전환
- 다크모드 구현: class 기반 토글, localStorage 영속성, useDarkMode hook + ThemeProvider
- 모바일 하단 탭바 추가 (BottomNavBar): 홈/게시판/채팅/지도/게임 5탭
- 반응형 Header 재작성: 데스크톱 네비 + 모바일 미니 헤더 + 다크모드 토글 버튼
- Home 페이지 재디자인: 히어로 섹션, 당근마켓 스타일 빠른메뉴, 콘텐츠 카드 그리드
- BoardList: PC 테이블 + 모바일 카드 이중 레이아웃, 커스텀 페이지네이션/검색바
- PostView: MUI Joy 전체 제거, max-w-3xl 중앙 레이아웃, 댓글 스레딩
- LoginForm / JoinForm: 순수 Tailwind 카드 레이아웃
- StyledButton: variant(primary/secondary/ghost/accent/danger/white) + size(sm/md/lg)
- 신규 유틸: axiosInstance, categoryUtils, sanitize, MediaBlock
- tailwind.config.js: 디자인 토큰 확장 (color, shadow, spacing, animation)