### PR TITLE
지도 화면 UX 전면 개선: 모듈 분리, 글래스모피즘 UI, 반응형 바텀시트

### DIFF
--- a/src/components/map/KakaoMapView.jsx
+++ b/src/components/map/KakaoMapView.jsx
@@ -1,1283 +1,145 @@
 import React from 'react';
+import MapSearchBar from './MapSearchBar';
+import MapCategoryBar from './MapCategoryBar';
+import PlaceListPanel from './PlaceListPanel';
+import PlaceDetailCard from './PlaceDetailCard';
+import MapControls from './MapControls';
 
-const KakaoMapView = ({
-  isMobile,
+/**
+ * 카카오맵 View — Tailwind 반응형 UI 셸
+ *
+ * 데스크톱: [지도 flex-1] + [사이드패널 w-80]
+ * 모바일:   [지도 full] + [바텀시트 fixed] or [상세 overlay]
+ */
+export default function KakaoMapView({
   mapContainerRef,
   locations,
   selectedPlace,
-  closeDetailSection,
-  recenterMap,
-  handleKeywordChange,
-  categories,
+  onCloseDetail,
   selectedCategory,
-  handleLocationClick,
+  onCategoryChange,
   searchQuery,
   setSearchQuery,
-  handleSearch,
+  onSearch,
   isSearching,
-  openList,
-  toggleList,
-  moveToCurrentLocation,
+  onPlaceClick,
+  onZoomIn,
+  onZoomOut,
+  onMyLocation,
   isLoadingLocation,
-  locationError,
   reviews,
-  showReviewForm,
-  newReview,
-  handleReviewChange,
-  handleRatingChange,
-  handleReviewSubmit,
-  setShowReviewForm
-}) => {
-  // 모바일 레이아웃
-  if (isMobile) {
-    return (
-      <div style={{ position: 'relative', width: '100%', height: '100vh' }}>
-        {/* 지도 전체 영역 */}
-        <div ref={mapContainerRef} style={{ width: '100%', height: '100%' }} />
-
-        {/* 상단 고정 헤더: 검색창 + 카테고리 버튼 */}
-        <div style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          padding: '10px',
-          backgroundColor: 'rgba(255,255,255,0.95)',
-          zIndex: 1100,
-        }}>
-          {/* 검색창 */}
-          <div style={{ 
-            display: 'flex', 
-            gap: '8px', 
-            marginBottom: '10px',
-            position: 'relative'
-          }}>
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="지역을 검색하세요"
-              style={{
-                flex: 1,
-                padding: '8px 12px',
-                border: '1px solid #ddd',
-                borderRadius: '4px',
-                fontSize: '0.9rem'
-              }}
-              onKeyPress={(e) => e.key === 'Enter' && handleSearch()}
-            />
-            <button
-              onClick={handleSearch}
-              disabled={isSearching}
-              style={{
-                padding: '8px 12px',
-                backgroundColor: '#4caf50',
-                color: '#fff',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: isSearching ? 'wait' : 'pointer',
-                opacity: isSearching ? '0.7' : '1',
-                fontSize: '0.9rem'
-              }}
-            >
-              {isSearching ? '검색 중...' : '검색'}
-            </button>
-          </div>
-
-          {/* 카테고리 버튼 */}
-          <div style={{ 
-            display: 'flex', 
-            gap: '8px', 
-            overflowX: 'auto',
-            paddingBottom: '5px'
-          }}>
-            {Object.keys(categories).map((key) => (
-              <button
-                key={key}
-                onClick={() => handleKeywordChange(categories[key])}
-                style={{
-                  padding: '6px 12px',
-                  border: selectedCategory === categories[key] ? '2px solid #4caf50' : '1px solid #ddd',
-                  borderRadius: '4px',
-                  backgroundColor: selectedCategory === categories[key] ? '#4caf50' : '#fff',
-                  color: selectedCategory === categories[key] ? '#fff' : '#000',
-                  cursor: 'pointer',
-                  fontSize: '0.8rem',
-                  whiteSpace: 'nowrap'
-                }}
-              >
-                {categories[key]}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* 현재 위치 버튼 */}
-        <div style={{
-          position: 'absolute',
-          top: 120,
-          right: 10,
-          zIndex: 1100,
-        }}>
-          <button
-            onClick={moveToCurrentLocation}
-            disabled={isLoadingLocation}
-            style={{
-              width: '32px',
-              height: '32px',
-              borderRadius: '50%',
-              backgroundColor: 'white',
-              color: '#4caf50',
-              border: 'none',
-              boxShadow: '0 2px 5px rgba(0,0,0,0.2)',
-              cursor: isLoadingLocation ? 'wait' : 'pointer',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              fontSize: '14px',
-              padding: 0
-            }}
-            title="현재 위치로 이동"
-          >
-            {isLoadingLocation ? 
-              <span style={{fontSize: '10px', color: '#4caf50'}}>⟳</span> :
-              <span style={{fontSize: '14px', color: '#4caf50'}}>📍</span>
-            }
-          </button>
-          {locationError && (
-            <div style={{
-              position: 'absolute',
-              top: '35px',
-              right: 0,
-              width: '180px',
-              padding: '6px',
-              backgroundColor: 'rgba(255,0,0,0.7)',
-              color: 'white',
-              borderRadius: '4px',
-              fontSize: '10px'
-            }}>
-              {locationError}
-            </div>
-          )}
-        </div>
-
-        {/* 하단: 리스트 토글 버튼 */}
-        <div style={{
-          position: 'absolute',
-          bottom: 10,
-          left: 10,
-          right: 10,
-          zIndex: 1100,
-          display: 'flex',
-          justifyContent: 'center',
-        }}>
-          <button
-            onClick={toggleList}
-            style={{
-              padding: '8px 16px',
-              backgroundColor: '#4caf50',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-              fontSize: '0.9rem',
-              boxShadow: '0 2px 4px rgba(0,0,0,0.2)'
-            }}
-          >
-            {openList ? '리스트 닫기' : '리스트 열기'}
-          </button>
-        </div>
-
-        {/* 모바일: 리스트 오버레이 (바텀 시트) */}
-        {openList && (
-          <div style={{
-            position: 'absolute',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            height: '60vh', // 전체 높이의 60%만 차지
-            backgroundColor: 'white',
-            zIndex: 1200,
-            borderTopLeftRadius: '15px',
-            borderTopRightRadius: '15px',
-            boxShadow: '0 -2px 10px rgba(0,0,0,0.1)',
-            overflowY: 'auto',
-            transition: 'transform 0.3s ease'
-          }}>
-            <div style={{
-              padding: '15px 10px',
-              borderBottom: '1px solid #eee',
-              position: 'sticky',
-              top: 0,
-              backgroundColor: 'white',
-              zIndex: 10,
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center'
-            }}>
-              <h3 style={{ 
-                margin: 0, 
-                fontSize: '1rem',
-                fontWeight: '600'
-              }}>
-                주변 장소 ({locations.length})
-              </h3>
-              <div style={{ 
-                width: '40px',
-                height: '5px',
-                backgroundColor: '#ddd',
-                borderRadius: '2px',
-                margin: '0 auto',
-                position: 'absolute',
-                top: '7px',
-                left: 0,
-                right: 0
-              }} />
-            </div>
-            
-            {/* 장소 리스트 */}
-            <ul style={{ 
-              listStyle: 'none', 
-              padding: '0 10px 15px', 
-              margin: 0 
-            }}>
-              {locations.length > 0 ? (
-                locations.map((place) => (
-                  <li 
-                    key={place.id}
-                    onClick={() => handleLocationClick(place)}
-                    style={{
-                      padding: '12px',
-                      borderBottom: '1px solid #f0f0f0',
-                      cursor: 'pointer',
-                      backgroundColor: 'white',
-                      borderRadius: '8px',
-                      marginTop: '10px',
-                      boxShadow: '0 1px 3px rgba(0,0,0,0.05)'
-                    }}
-                  >
-                    <div style={{ 
-                      display: 'flex', 
-                      alignItems: 'flex-start'
-                    }}>
-                      <div style={{ 
-                        minWidth: '50px', 
-                        height: '50px',
-                        borderRadius: '8px',
-                        backgroundColor: '#f3f3f3',
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        marginRight: '12px',
-                        overflow: 'hidden'
-                      }}>
-                        {place.category_name && (
-                          <span style={{
-                            fontSize: '24px',
-                            color: '#4caf50'
-                          }}>
-                            {place.category_name.includes('동물병원') ? '🏥' : 
-                            place.category_name.includes('애견카페') ? '☕' : 
-                            place.category_name.includes('애견샵') ? '🛍️' : 
-                            place.category_name.includes('공원') ? '🌳' : 
-                            place.category_name.includes('호텔') ? '🏨' : '📍'}
-                          </span>
-                        )}
-                      </div>
-                      <div style={{ flex: 1 }}>
-                        <h4 style={{ 
-                          margin: '0 0 4px 0', 
-                          fontSize: '0.95rem',
-                          fontWeight: '600'
-                        }}>
-                          {place.place_name}
-                        </h4>
-                        <p style={{ 
-                          margin: 0, 
-                          fontSize: '0.85rem', 
-                          color: '#666',
-                          lineHeight: '1.4'
-                        }}>
-                          {place.address_name}
-                        </p>
-                        {place.category_name && (
-                          <span style={{
-                            display: 'inline-block',
-                            fontSize: '0.75rem',
-                            color: '#4caf50',
-                            backgroundColor: '#e8f5e9',
-                            padding: '2px 6px',
-                            borderRadius: '3px',
-                            marginTop: '4px'
-                          }}>
-                            {place.category_name}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  </li>
-                ))
-              ) : (
-                <li style={{ 
-                  padding: '20px',
-                  textAlign: 'center',
-                  color: '#666',
-                  backgroundColor: '#f8f8f8',
-                  borderRadius: '8px',
-                  marginTop: '10px'
-                }}>
-                  근처에 해당 장소가 없습니다.
-                </li>
-              )}
-            </ul>
-          </div>
-        )}
-
-        {/* 모바일: 상세정보 오버레이 */}
-        {selectedPlace && (
-          <div style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-            backgroundColor: '#fff',
-            zIndex: 1300,
-            overflowY: 'auto',
-            padding: '20px 15px 80px 15px',
-          }}>
-            <button
-              onClick={closeDetailSection}
-              style={{
-                position: 'fixed',
-                top: '10px',
-                right: '10px',
-                padding: '8px 12px',
-                backgroundColor: '#4caf50',
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer',
-                fontSize: '0.9rem',
-                zIndex: 1301
-              }}
-            >
-              닫기
-            </button>
-            
-            {/* 작은 지도 표시 영역 */}
-            <div style={{ 
-              marginTop: '40px', 
-              marginBottom: '15px',
-              position: 'relative',
-              height: '150px',
-              borderRadius: '8px',
-              overflow: 'hidden',
-              boxShadow: '0 2px 5px rgba(0,0,0,0.1)',
-              backgroundColor: '#f3f3f3'
-            }}>
-              <div 
-                onClick={closeDetailSection}
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  height: '100%',
-                  zIndex: 5,
-                  backgroundColor: 'rgba(0,0,0,0.05)',
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  cursor: 'pointer'
-                }}
-              >
-                <span style={{
-                  backgroundColor: 'rgba(255,255,255,0.8)',
-                  padding: '5px 10px',
-                  borderRadius: '4px',
-                  fontSize: '0.8rem',
-                  color: '#555',
-                  boxShadow: '0 1px 3px rgba(0,0,0,0.2)'
-                }}>
-                  지도 크게 보기
-                </span>
-              </div>
-              
-              {/* 지도 이미지 대신 위치 정보 표시 */}
-              <div style={{
-                width: '100%',
-                height: '100%',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
-                alignItems: 'center',
-                padding: '0 15px',
-                textAlign: 'center'
-              }}>
-                <div style={{
-                  fontSize: '1rem',
-                  fontWeight: 'bold',
-                  marginBottom: '8px',
-                  color: '#4caf50'
-                }}>
-                  <span role="img" aria-label="위치" style={{ marginRight: '5px' }}>📍</span>
-                  위치 정보
-                </div>
-                <div style={{
-                  fontSize: '0.85rem',
-                  color: '#555',
-                  marginBottom: '5px',
-                  wordBreak: 'break-all'
-                }}>
-                  {selectedPlace.address}
-                </div>
-                {selectedPlace.phone && (
-                  <div style={{
-                    fontSize: '0.85rem',
-                    color: '#555'
-                  }}>
-                    <span style={{ fontWeight: '500' }}>연락처:</span> {selectedPlace.phone}
-                  </div>
-                )}
-              </div>
-            </div>
-            
-            <div>
-              <h2 style={{ 
-                fontWeight: 'bold', 
-                fontSize: '1.2rem',
-                marginBottom: '15px',
-                wordBreak: 'keep-all',
-                lineHeight: '1.4'
-              }}>
-                {selectedPlace.name}
-              </h2>
-              
-              <div style={{
-                display: 'flex',
-                justifyContent: 'center',
-                marginBottom: '15px'
-              }}>
-                <img
-                  src={selectedPlace.image || `${process.env.PUBLIC_URL}/images/borikkori_brown.png`}
-                  alt={selectedPlace.name}
-                  style={{ 
-                    width: '100%', 
-                    maxWidth: '300px', 
-                    height: 'auto',
-                    borderRadius: '8px'
-                  }}
-                />
-              </div>
-              
-              <div style={{ 
-                marginTop: '15px',
-                backgroundColor: '#f8f8f8',
-                padding: '15px',
-                borderRadius: '8px',
-                marginBottom: '20px'
-              }}>
-                <p style={{ 
-                  marginBottom: '10px',
-                  fontSize: '0.95rem',
-                  lineHeight: '1.5',
-                  wordBreak: 'break-all'
-                }}>
-                  <strong>주소:</strong> {selectedPlace.address}
-                </p>
-                {selectedPlace.phone && (
-                  <p style={{ 
-                    marginBottom: '10px',
-                    fontSize: '0.95rem'
-                  }}>
-                    <strong>전화:</strong> {selectedPlace.phone}
-                  </p>
-                )}
-                {selectedPlace.category_name && (
-                  <p style={{ 
-                    marginBottom: '10px',
-                    fontSize: '0.95rem'
-                  }}>
-                    <strong>카테고리:</strong> {selectedPlace.category_name}
-                  </p>
-                )}
-                <div style={{
-                  display: 'flex',
-                  justifyContent: 'flex-end',
-                  marginTop: '5px'
-                }}>
-                  {selectedPlace.place_url && (
-                    <a
-                      href={selectedPlace.place_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{
-                        display: 'inline-block',
-                        padding: '6px 12px',
-                        backgroundColor: '#4caf50',
-                        color: 'white',
-                        textDecoration: 'none',
-                        borderRadius: '4px',
-                        fontSize: '0.85rem',
-                        textAlign: 'center',
-                        boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
-                      }}
-                    >
-                      카카오맵에서 보기
-                    </a>
-                  )}
-                </div>
-              </div>
-              
-              {/* 리뷰 섹션 */}
-              <div style={{ marginTop: '10px' }}>
-                <div style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  marginBottom: '15px'
-                }}>
-                  <h3 style={{ 
-                    fontSize: '1.1rem',
-                    margin: 0
-                  }}>
-                    리뷰 ({reviews.length})
-                  </h3>
-                  <button
-                    onClick={() => setShowReviewForm(!showReviewForm)}
-                    style={{
-                      padding: '6px 12px',
-                      backgroundColor: '#4caf50',
-                      color: 'white',
-                      border: 'none',
-                      borderRadius: '4px',
-                      cursor: 'pointer',
-                      fontSize: '0.85rem'
-                    }}
-                  >
-                    {showReviewForm ? '취소' : '리뷰 작성하기'}
-                  </button>
-                </div>
-                
-                {/* 리뷰 작성 폼 */}
-                {showReviewForm && (
-                  <form 
-                    onSubmit={handleReviewSubmit}
-                    style={{
-                      backgroundColor: '#f5f5f5',
-                      padding: '15px',
-                      borderRadius: '8px',
-                      marginBottom: '20px'
-                    }}
-                  >
-                    <div style={{ marginBottom: '12px' }}>
-                      <label 
-                        htmlFor="userName" 
-                        style={{ 
-                          display: 'block', 
-                          marginBottom: '5px',
-                          fontSize: '0.9rem',
-                          fontWeight: '500'
-                        }}
-                      >
-                        닉네임
-                      </label>
-                      <input
-                        type="text"
-                        id="userName"
-                        name="userName"
-                        value={newReview.userName}
-                        onChange={handleReviewChange}
-                        required
-                        style={{
-                          width: '100%',
-                          padding: '8px 12px',
-                          border: '1px solid #ddd',
-                          borderRadius: '4px',
-                          fontSize: '0.9rem'
-                        }}
-                      />
-                    </div>
-                    
-                    <div style={{ marginBottom: '12px' }}>
-                      <label 
-                        style={{ 
-                          display: 'block', 
-                          marginBottom: '5px',
-                          fontSize: '0.9rem',
-                          fontWeight: '500'
-                        }}
-                      >
-                        별점
-                      </label>
-                      <div style={{ display: 'flex', gap: '5px' }}>
-                        {[1, 2, 3, 4, 5].map((star) => (
-                          <button
-                            key={star}
-                            type="button"
-                            onClick={() => handleRatingChange(star)}
-                            style={{
-                              background: 'none',
-                              border: 'none',
-                              cursor: 'pointer',
-                              fontSize: '1.5rem',
-                              color: star <= newReview.rating ? '#ffbb00' : '#ddd',
-                              padding: '0 2px'
-                            }}
-                          >
-                            ★
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                    
-                    <div style={{ marginBottom: '15px' }}>
-                      <label 
-                        htmlFor="content" 
-                        style={{ 
-                          display: 'block', 
-                          marginBottom: '5px',
-                          fontSize: '0.9rem',
-                          fontWeight: '500'
-                        }}
-                      >
-                        내용
-                      </label>
-                      <textarea
-                        id="content"
-                        name="content"
-                        value={newReview.content}
-                        onChange={handleReviewChange}
-                        required
-                        rows={4}
-                        style={{
-                          width: '100%',
-                          padding: '8px 12px',
-                          border: '1px solid #ddd',
-                          borderRadius: '4px',
-                          fontSize: '0.9rem',
-                          resize: 'vertical'
-                        }}
-                      />
-                    </div>
-                    
-                    <button
-                      type="submit"
-                      style={{
-                        padding: '8px 16px',
-                        backgroundColor: '#4caf50',
-                        color: 'white',
-                        border: 'none',
-                        borderRadius: '4px',
-                        cursor: 'pointer',
-                        fontSize: '0.9rem',
-                        width: '100%'
-                      }}
-                    >
-                      리뷰 등록하기
-                    </button>
-                  </form>
-                )}
-                
-                {/* 리뷰 목록 */}
-                <div>
-                  {reviews.length > 0 ? (
-                    <ul style={{ 
-                      listStyle: 'none', 
-                      padding: 0, 
-                      margin: 0 
-                    }}>
-                      {reviews.map((review) => (
-                        <li 
-                          key={review.id}
-                          style={{
-                            padding: '15px',
-                            borderBottom: '1px solid #eee',
-                            marginBottom: '10px'
-                          }}
-                        >
-                          <div style={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            marginBottom: '8px'
-                          }}>
-                            <div style={{ fontWeight: '500' }}>
-                              {review.userName}
-                            </div>
-                            <div style={{ fontSize: '0.85rem', color: '#888' }}>
-                              {review.date}
-                            </div>
-                          </div>
-                          
-                          <div style={{
-                            color: '#ffbb00',
-                            fontSize: '0.9rem',
-                            marginBottom: '8px'
-                          }}>
-                            {'★'.repeat(review.rating)}{'☆'.repeat(5 - review.rating)}
-                          </div>
-                          
-                          <p style={{ 
-                            margin: 0,
-                            fontSize: '0.95rem',
-                            lineHeight: '1.5',
-                            color: '#333'
-                          }}>
-                            {review.content}
-                          </p>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <div style={{
-                      padding: '20px',
-                      textAlign: 'center',
-                      color: '#888',
-                      backgroundColor: '#f8f8f8',
-                      borderRadius: '8px'
-                    }}>
-                      아직 리뷰가 없습니다. 첫 리뷰를 작성해보세요!
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // 데스크톱 레이아웃
+  favorites,
+  isFavorite,
+  onToggleFavorite,
+  showFavorites,
+  onToggleShowFavorites,
+  showResearch,
+  onResearchArea,
+}) {
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100vh' }}>
-      {/* 지도 전체 영역 */}
-      <div ref={mapContainerRef} style={{ width: '100%', height: '100%' }} />
+    <div className="relative w-full flex overflow-hidden
+                    bg-secondary dark:bg-dark-surface transition-colors duration-200"
+         style={{ height: 'calc(100vh - var(--header-height, 60px))' }}>
 
-      {/* 상단 고정 헤더: 검색창 + 카테고리 버튼 */}
-      <div style={{
-        position: 'absolute',
-        top: 20,
-        left: 20,
-        right: 20,
-        padding: '15px',
-        backgroundColor: 'rgba(255,255,255,0.95)',
-        borderRadius: '8px',
-        boxShadow: '0 2px 10px rgba(0,0,0,0.1)',
-        zIndex: 1100,
-      }}>
-        {/* 검색창 */}
-        <div style={{ 
-          display: 'flex', 
-          gap: '10px', 
-          marginBottom: '15px',
-          maxWidth: '600px',
-          margin: '0 auto 15px'
-        }}>
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="지역을 검색하세요"
-            style={{
-              flex: 1,
-              padding: '10px 15px',
-              border: '1px solid #ddd',
-              borderRadius: '4px',
-              fontSize: '1rem'
-            }}
-            onKeyPress={(e) => e.key === 'Enter' && handleSearch()}
-          />
-          <button
-            onClick={handleSearch}
-            disabled={isSearching}
-            style={{
-              padding: '10px 20px',
-              backgroundColor: '#4caf50',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: isSearching ? 'wait' : 'pointer',
-              opacity: isSearching ? '0.7' : '1',
-              fontSize: '1rem'
-            }}
-          >
-            {isSearching ? '검색 중...' : '검색'}
-          </button>
+      {/* ============================================================
+          지도 영역 (flex-1)
+          ============================================================ */}
+      <div className="flex-1 relative min-w-0">
+        {/* 카카오맵 캔버스 */}
+        <div ref={mapContainerRef} className="absolute inset-0" />
+
+        {/* ── 상단 오버레이: 검색 + 카테고리 ── */}
+        <div className="absolute top-0 inset-x-0 z-20 p-3 pb-0
+                        md:pr-[calc(20rem+0.75rem)]">
+          <div className="space-y-2">
+            <MapSearchBar
+              searchQuery={searchQuery}
+              setSearchQuery={setSearchQuery}
+              onSearch={onSearch}
+              isSearching={isSearching}
+            />
+            <MapCategoryBar
+              selectedCategory={selectedCategory}
+              onCategoryChange={onCategoryChange}
+              locationCount={locations.length}
+            />
+          </div>
         </div>
 
-        {/* 카테고리 버튼 */}
-        <div style={{ 
-          display: 'flex', 
-          gap: '10px', 
-          justifyContent: 'center',
-          flexWrap: 'wrap'
-        }}>
-          {Object.keys(categories).map((key) => (
+        {/* ── "이 지역 재검색" 플로팅 버튼 (네이버맵 스타일) ── */}
+        {showResearch && (
+          <div className="absolute top-[6.5rem] left-1/2 -translate-x-1/2 z-20 md:left-1/2">
             <button
-              key={key}
-              onClick={() => handleKeywordChange(categories[key])}
-              style={{
-                padding: '8px 16px',
-                border: selectedCategory === categories[key] ? '2px solid #4caf50' : '1px solid #ddd',
-                borderRadius: '4px',
-                backgroundColor: selectedCategory === categories[key] ? '#4caf50' : '#fff',
-                color: selectedCategory === categories[key] ? '#fff' : '#000',
-                cursor: 'pointer',
-                fontSize: '0.9rem',
-                transition: 'all 0.2s'
-              }}
+              onClick={onResearchArea}
+              className="flex items-center gap-2 px-4 py-2.5 rounded-full
+                         bg-white/95 dark:bg-dark-surface2/95 backdrop-blur-md
+                         shadow-lg border border-white/50 dark:border-dark-border/50
+                         text-sm font-semibold text-primary dark:text-accent
+                         hover:shadow-xl hover:scale-[1.02]
+                         active:scale-95 transition-all duration-200"
             >
-              {categories[key]}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* 우측: 장소 리스트 */}
-      <div style={{
-        position: 'absolute',
-        top: 20,
-        right: 20,
-        width: '300px',
-        maxHeight: 'calc(100vh - 40px)',
-        backgroundColor: 'rgba(255,255,255,0.95)',
-        borderRadius: '8px',
-        boxShadow: '0 2px 10px rgba(0,0,0,0.1)',
-        overflowY: 'auto',
-        zIndex: 1100,
-      }}>
-        <div style={{ padding: '15px' }}>
-          <h3 style={{ 
-            margin: '0 0 15px 0',
-            fontSize: '1.1rem',
-            fontWeight: '600'
-          }}>
-            주변 장소
-          </h3>
-          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-            {locations.length > 0 ? (
-              locations.map((place) => (
-                <li
-                  key={place.id}
-                  onClick={() => handleLocationClick(place)}
-                  style={{
-                    cursor: 'pointer',
-                    padding: '12px',
-                    borderBottom: '1px solid #eee',
-                    transition: 'background-color 0.2s'
-                  }}
-                  onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#f5f5f5'}
-                  onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#fff'}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <img
-                      src={place.imageUrl || `${process.env.PUBLIC_URL}/images/borikkori_brown.png`}
-                      alt={place.place_name}
-                      style={{ 
-                        width: '60px', 
-                        height: '60px', 
-                        objectFit: 'cover', 
-                        borderRadius: '8px',
-                        marginRight: '12px' 
-                      }}
-                    />
-                    <div style={{ flex: 1 }}>
-                      <h4 style={{ 
-                        margin: '0 0 4px 0', 
-                        fontSize: '0.95rem',
-                        fontWeight: '600'
-                      }}>
-                        {place.place_name}
-                      </h4>
-                      <p style={{ 
-                        margin: 0, 
-                        fontSize: '0.85rem', 
-                        color: '#666',
-                        lineHeight: '1.4'
-                      }}>
-                        {place.address_name}
-                      </p>
-                      {place.category_name && (
-                        <span style={{
-                          display: 'inline-block',
-                          fontSize: '0.75rem',
-                          color: '#4caf50',
-                          backgroundColor: '#e8f5e9',
-                          padding: '2px 6px',
-                          borderRadius: '3px',
-                          marginTop: '4px'
-                        }}>
-                          {place.category_name}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </li>
-              ))
-            ) : (
-              <li style={{ 
-                padding: '20px',
-                textAlign: 'center',
-                color: '#666'
-              }}>
-                근처에 해당 장소가 없습니다.
-              </li>
-            )}
-          </ul>
-        </div>
-      </div>
-
-      {/* 데스크톱: 상세정보 패널 */}
-      {selectedPlace && (
-        <div style={{
-          position: 'absolute',
-          top: 20,
-          left: 20,
-          width: '400px',
-          maxHeight: 'calc(100vh - 40px)',
-          backgroundColor: 'white',
-          borderRadius: '8px',
-          boxShadow: '0 2px 10px rgba(0,0,0,0.15)',
-          overflowY: 'auto',
-          zIndex: 1200,
-        }}>
-          <div style={{ 
-            position: 'sticky',
-            top: 0, 
-            backgroundColor: 'white',
-            padding: '15px',
-            borderBottom: '1px solid #eee',
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            borderTopLeftRadius: '8px',
-            borderTopRightRadius: '8px',
-            zIndex: 10
-          }}>
-            <h2 style={{ 
-              fontWeight: 'bold', 
-              fontSize: '1.2rem',
-              margin: 0,
-              maxWidth: 'calc(100% - 70px)',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap'
-            }}>
-              {selectedPlace.name}
-            </h2>
-            <button
-              onClick={closeDetailSection}
-              style={{
-                padding: '6px 12px',
-                backgroundColor: '#4caf50',
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer',
-                fontSize: '0.85rem'
-              }}
-            >
-              닫기
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+              이 지역 재검색
             </button>
           </div>
-          
-          <div style={{ padding: '0 15px 20px 15px' }}>
-            <div style={{
-              display: 'flex',
-              justifyContent: 'center',
-              marginBottom: '15px',
-              marginTop: '15px'
-            }}>
-              <img
-                src={selectedPlace.image || `${process.env.PUBLIC_URL}/images/borikkori_brown.png`}
-                alt={selectedPlace.name}
-                style={{ 
-                  width: '100%', 
-                  maxWidth: '300px', 
-                  height: 'auto',
-                  borderRadius: '8px',
-                  boxShadow: '0 1px 4px rgba(0,0,0,0.1)'
-                }}
+        )}
+
+        {/* ── 우하단 컨트롤 ── */}
+        <div className="absolute bottom-28 md:bottom-6 right-3 z-20">
+          <MapControls
+            onZoomIn={onZoomIn}
+            onZoomOut={onZoomOut}
+            onMyLocation={onMyLocation}
+            isLoadingLocation={isLoadingLocation}
+          />
+        </div>
+
+        {/* ── 모바일: 장소 상세 오버레이 ── */}
+        {selectedPlace && (
+          <div className="md:hidden fixed inset-0 z-40 flex flex-col">
+            <button className="flex-shrink-0 h-12 w-full" onClick={onCloseDetail} aria-label="닫기" />
+            <div className="flex-1 rounded-t-2xl overflow-hidden shadow-[0_-8px_30px_rgba(0,0,0,0.15)]">
+              <PlaceDetailCard
+                place={selectedPlace}
+                onClose={onCloseDetail}
+                isFavorite={isFavorite(selectedPlace.id)}
+                onToggleFavorite={onToggleFavorite}
+                reviews={reviews}
               />
             </div>
-            
-            <div style={{ 
-              marginTop: '15px',
-              backgroundColor: '#f8f8f8',
-              padding: '15px',
-              borderRadius: '8px',
-              marginBottom: '20px'
-            }}>
-              <p style={{ 
-                marginBottom: '10px',
-                fontSize: '0.95rem',
-                lineHeight: '1.5'
-              }}>
-                <strong>주소:</strong> {selectedPlace.address}
-              </p>
-              {selectedPlace.phone && (
-                <p style={{ 
-                  marginBottom: '10px',
-                  fontSize: '0.95rem'
-                }}>
-                  <strong>전화:</strong> {selectedPlace.phone}
-                </p>
-              )}
-              {selectedPlace.category_name && (
-                <p style={{ 
-                  marginBottom: '10px',
-                  fontSize: '0.95rem'
-                }}>
-                  <strong>카테고리:</strong> {selectedPlace.category_name}
-                </p>
-              )}
-              <div style={{
-                display: 'flex',
-                justifyContent: 'flex-end',
-                marginTop: '5px'
-              }}>
-                {selectedPlace.place_url && (
-                  <a
-                    href={selectedPlace.place_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{
-                      display: 'inline-block',
-                      padding: '6px 12px',
-                      backgroundColor: '#4caf50',
-                      color: 'white',
-                      textDecoration: 'none',
-                      borderRadius: '4px',
-                      fontSize: '0.85rem',
-                      textAlign: 'center',
-                      boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
-                    }}
-                  >
-                    카카오맵에서 보기
-                  </a>
-                )}
-              </div>
-            </div>
-            
-            {/* 리뷰 섹션 */}
-            <div style={{ marginTop: '10px' }}>
-              <div style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                marginBottom: '15px'
-              }}>
-                <h3 style={{ 
-                  fontSize: '1.1rem',
-                  margin: 0
-                }}>
-                  리뷰 ({reviews.length})
-                </h3>
-                <button
-                  onClick={() => setShowReviewForm(!showReviewForm)}
-                  style={{
-                    padding: '6px 12px',
-                    backgroundColor: '#4caf50',
-                    color: 'white',
-                    border: 'none',
-                    borderRadius: '4px',
-                    cursor: 'pointer',
-                    fontSize: '0.85rem'
-                  }}
-                >
-                  {showReviewForm ? '취소' : '리뷰 작성하기'}
-                </button>
-              </div>
-              
-              {/* 리뷰 작성 폼 */}
-              {showReviewForm && (
-                <form 
-                  onSubmit={handleReviewSubmit}
-                  style={{
-                    backgroundColor: '#f5f5f5',
-                    padding: '15px',
-                    borderRadius: '8px',
-                    marginBottom: '20px'
-                  }}
-                >
-                  <div style={{ marginBottom: '12px' }}>
-                    <label 
-                      htmlFor="desktop-userName" 
-                      style={{ 
-                        display: 'block', 
-                        marginBottom: '5px',
-                        fontSize: '0.9rem',
-                        fontWeight: '500'
-                      }}
-                    >
-                      닉네임
-                    </label>
-                    <input
-                      type="text"
-                      id="desktop-userName"
-                      name="userName"
-                      value={newReview.userName}
-                      onChange={handleReviewChange}
-                      required
-                      style={{
-                        width: '100%',
-                        padding: '8px 12px',
-                        border: '1px solid #ddd',
-                        borderRadius: '4px',
-                        fontSize: '0.9rem'
-                      }}
-                    />
-                  </div>
-                  
-                  <div style={{ marginBottom: '12px' }}>
-                    <label 
-                      style={{ 
-                        display: 'block', 
-                        marginBottom: '5px',
-                        fontSize: '0.9rem',
-                        fontWeight: '500'
-                      }}
-                    >
-                      별점
-                    </label>
-                    <div style={{ display: 'flex', gap: '5px' }}>
-                      {[1, 2, 3, 4, 5].map((star) => (
-                        <button
-                          key={star}
-                          type="button"
-                          onClick={() => handleRatingChange(star)}
-                          style={{
-                            background: 'none',
-                            border: 'none',
-                            cursor: 'pointer',
-                            fontSize: '1.5rem',
-                            color: star <= newReview.rating ? '#ffbb00' : '#ddd',
-                            padding: '0 2px'
-                          }}
-                        >
-                          ★
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  
-                  <div style={{ marginBottom: '15px' }}>
-                    <label 
-                      htmlFor="desktop-content" 
-                      style={{ 
-                        display: 'block', 
-                        marginBottom: '5px',
-                        fontSize: '0.9rem',
-                        fontWeight: '500'
-                      }}
-                    >
-                      내용
-                    </label>
-                    <textarea
-                      id="desktop-content"
-                      name="content"
-                      value={newReview.content}
-                      onChange={handleReviewChange}
-                      required
-                      rows={4}
-                      style={{
-                        width: '100%',
-                        padding: '8px 12px',
-                        border: '1px solid #ddd',
-                        borderRadius: '4px',
-                        fontSize: '0.9rem',
-                        resize: 'vertical'
-                      }}
-                    />
-                  </div>
-                  
-                  <button
-                    type="submit"
-                    style={{
-                      padding: '8px 16px',
-                      backgroundColor: '#4caf50',
-                      color: 'white',
-                      border: 'none',
-                      borderRadius: '4px',
-                      cursor: 'pointer',
-                      fontSize: '0.9rem',
-                      width: '100%'
-                    }}
-                  >
-                    리뷰 등록하기
-                  </button>
-                </form>
-              )}
-              
-              {/* 리뷰 목록 */}
-              <div>
-                {reviews.length > 0 ? (
-                  <ul style={{ 
-                    listStyle: 'none', 
-                    padding: 0, 
-                    margin: 0 
-                  }}>
-                    {reviews.map((review) => (
-                      <li 
-                        key={review.id}
-                        style={{
-                          padding: '15px',
-                          borderBottom: '1px solid #eee',
-                          marginBottom: '10px'
-                        }}
-                      >
-                        <div style={{
-                          display: 'flex',
-                          justifyContent: 'space-between',
-                          marginBottom: '8px'
-                        }}>
-                          <div style={{ fontWeight: '500' }}>
-                            {review.userName}
-                          </div>
-                          <div style={{ fontSize: '0.85rem', color: '#888' }}>
-                            {review.date}
-                          </div>
-                        </div>
-                        
-                        <div style={{
-                          color: '#ffbb00',
-                          fontSize: '0.9rem',
-                          marginBottom: '8px'
-                        }}>
-                          {'★'.repeat(review.rating)}{'☆'.repeat(5 - review.rating)}
-                        </div>
-                        
-                        <p style={{ 
-                          margin: 0,
-                          fontSize: '0.95rem',
-                          lineHeight: '1.5',
-                          color: '#333'
-                        }}>
-                          {review.content}
-                        </p>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <div style={{
-                    padding: '20px',
-                    textAlign: 'center',
-                    color: '#888',
-                    backgroundColor: '#f8f8f8',
-                    borderRadius: '8px'
-                  }}>
-                    아직 리뷰가 없습니다. 첫 리뷰를 작성해보세요!
-                  </div>
-                )}
-              </div>
-            </div>
           </div>
+        )}
+      </div>
+
+      {/* ============================================================
+          사이드 영역
+          ============================================================ */}
+      {selectedPlace ? (
+        <div className="hidden md:flex flex-col w-80 flex-shrink-0 h-full
+                        border-l border-gray-100 dark:border-dark-border">
+          <PlaceDetailCard
+            place={selectedPlace}
+            onClose={onCloseDetail}
+            isFavorite={isFavorite(selectedPlace.id)}
+            onToggleFavorite={onToggleFavorite}
+            reviews={reviews}
+          />
         </div>
+      ) : (
+        <PlaceListPanel
+          locations={locations}
+          selectedPlace={selectedPlace}
+          onPlaceClick={onPlaceClick}
+          isFavorite={isFavorite}
+          onToggleFavorite={onToggleFavorite}
+          showFavorites={showFavorites}
+          favorites={favorites}
+          onToggleShowFavorites={onToggleShowFavorites}
+        />
       )}
     </div>
   );
-};
-
-export default KakaoMapView;
+}

--- a/src/components/map/MapCategoryBar.jsx
+++ b/src/components/map/MapCategoryBar.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { CATEGORIES } from '../../utils/mapConstants';
+
+/**
+ * 카테고리 칩 바 — 결과 카운트 배지 + 스크롤
+ * (네이버/구글맵 스타일)
+ */
+export default function MapCategoryBar({ selectedCategory, onCategoryChange, locationCount = 0 }) {
+  return (
+    <div className="flex gap-2 overflow-x-auto scrollbar-hide py-0.5 -mx-1 px-1">
+      {CATEGORIES.map((cat) => {
+        const isSelected = selectedCategory === cat.keyword;
+        return (
+          <button
+            key={cat.key}
+            onClick={() => onCategoryChange(cat.keyword)}
+            className={`flex items-center gap-1.5 px-3.5 py-2 rounded-full text-[13px] font-medium
+                        whitespace-nowrap flex-shrink-0 transition-all duration-200
+                        ${isSelected
+                          ? 'bg-primary dark:bg-accent text-white shadow-md shadow-primary/25 dark:shadow-accent/25'
+                          : 'bg-white/80 dark:bg-dark-surface2/80 backdrop-blur-sm text-content-primary dark:text-gray-300 shadow-sm hover:shadow-md hover:scale-[1.02]'
+                        }`}
+          >
+            <span className="text-base leading-none">{cat.emoji}</span>
+            <span>{cat.label}</span>
+            {/* 선택된 카테고리에 결과 카운트 표시 */}
+            {isSelected && locationCount > 0 && (
+              <span className="ml-0.5 bg-white/25 text-[10px] px-1.5 py-0.5 rounded-full font-bold leading-none">
+                {locationCount}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/map/MapControls.jsx
+++ b/src/components/map/MapControls.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+/**
+ * 지도 컨트롤 버튼 — 나침반 스타일 원형 FAB
+ * (구글맵/네이버맵 스타일)
+ */
+export default function MapControls({ onZoomIn, onZoomOut, onMyLocation, isLoadingLocation }) {
+  const btnClass = `w-11 h-11 rounded-full flex items-center justify-center
+                    bg-white/90 dark:bg-dark-surface2/90 backdrop-blur-sm
+                    shadow-lg border border-white/50 dark:border-dark-border/50
+                    text-content-primary dark:text-white
+                    hover:bg-white dark:hover:bg-dark-surface3
+                    active:scale-90 transition-all duration-150`;
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      {/* 내 위치 — 상단에 분리 (구글맵 스타일) */}
+      <button onClick={onMyLocation} className={btnClass} aria-label="내 위치" disabled={isLoadingLocation}>
+        {isLoadingLocation ? (
+          <div className="w-5 h-5 border-2 border-primary/30 border-t-primary dark:border-accent/30 dark:border-t-accent rounded-full animate-spin" />
+        ) : (
+          <svg className="w-5 h-5 text-primary dark:text-accent" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <circle cx="12" cy="12" r="3" strokeWidth={2} />
+            <path strokeLinecap="round" strokeWidth={2} d="M12 2v4M12 18v4M2 12h4M18 12h4" />
+          </svg>
+        )}
+      </button>
+
+      {/* 줌 그룹 — 하나로 묶기 */}
+      <div className="rounded-full overflow-hidden shadow-lg border border-white/50 dark:border-dark-border/50">
+        <button onClick={onZoomIn} aria-label="확대"
+          className="w-11 h-10 flex items-center justify-center
+                     bg-white/90 dark:bg-dark-surface2/90 backdrop-blur-sm
+                     text-content-primary dark:text-white
+                     hover:bg-gray-50 dark:hover:bg-dark-surface3
+                     active:bg-gray-100 transition-all">
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v12M6 12h12" />
+          </svg>
+        </button>
+        <div className="h-px bg-gray-200 dark:bg-dark-border" />
+        <button onClick={onZoomOut} aria-label="축소"
+          className="w-11 h-10 flex items-center justify-center
+                     bg-white/90 dark:bg-dark-surface2/90 backdrop-blur-sm
+                     text-content-primary dark:text-white
+                     hover:bg-gray-50 dark:hover:bg-dark-surface3
+                     active:bg-gray-100 transition-all">
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 12h12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/map/MapSearchBar.jsx
+++ b/src/components/map/MapSearchBar.jsx
@@ -1,0 +1,161 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { LS_KEYS } from '../../utils/mapConstants';
+
+/**
+ * 지도 검색창 — 글래스모피즘, 최근 검색어, X 지우기
+ * (구글맵/네이버맵 스타일)
+ */
+export default function MapSearchBar({ searchQuery, setSearchQuery, onSearch, isSearching }) {
+  const [showRecent, setShowRecent] = useState(false);
+  const [recentSearches, setRecentSearches] = useState(() => {
+    try { return JSON.parse(localStorage.getItem(LS_KEYS.RECENT_SEARCHES) || '[]'); }
+    catch { return []; }
+  });
+  const inputRef = useRef(null);
+  const wrapperRef = useRef(null);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) setShowRecent(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const saveRecent = (q) => {
+    if (!q.trim()) return;
+    const next = [q, ...recentSearches.filter(s => s !== q)].slice(0, 8);
+    setRecentSearches(next);
+    localStorage.setItem(LS_KEYS.RECENT_SEARCHES, JSON.stringify(next));
+  };
+
+  const handleSearch = () => {
+    if (!searchQuery.trim()) return;
+    saveRecent(searchQuery.trim());
+    setShowRecent(false);
+    onSearch();
+  };
+
+  const handleRecentClick = (q) => {
+    setSearchQuery(q);
+    setShowRecent(false);
+    saveRecent(q);
+    setTimeout(() => onSearch(q), 50);
+  };
+
+  const removeRecent = (e, q) => {
+    e.stopPropagation();
+    const next = recentSearches.filter(s => s !== q);
+    setRecentSearches(next);
+    localStorage.setItem(LS_KEYS.RECENT_SEARCHES, JSON.stringify(next));
+  };
+
+  const clearAll = (e) => {
+    e.stopPropagation();
+    setRecentSearches([]);
+    localStorage.removeItem(LS_KEYS.RECENT_SEARCHES);
+  };
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      {/* 검색 입력 — 글래스모피즘 */}
+      <div className="flex items-center
+                      bg-white/80 dark:bg-dark-surface2/80
+                      backdrop-blur-md rounded-2xl shadow-lg
+                      border border-white/50 dark:border-dark-border/50
+                      overflow-hidden
+                      focus-within:ring-2 focus-within:ring-primary/40 dark:focus-within:ring-accent/40
+                      transition-all duration-200">
+        {/* 돋보기 */}
+        <div className="pl-3.5 flex-shrink-0">
+          {isSearching ? (
+            <div className="w-5 h-5 border-2 border-primary/30 border-t-primary dark:border-accent/30 dark:border-t-accent rounded-full animate-spin" />
+          ) : (
+            <svg className="w-5 h-5 text-content-secondary dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          )}
+        </div>
+
+        <input
+          ref={inputRef}
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onFocus={() => recentSearches.length > 0 && setShowRecent(true)}
+          onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+          placeholder="장소·주소·키워드 검색"
+          className="flex-1 bg-transparent px-3 py-3 text-sm
+                     text-content-primary dark:text-white
+                     placeholder:text-content-disabled dark:placeholder:text-gray-500
+                     focus:outline-none"
+        />
+
+        {/* X 지우기 */}
+        {searchQuery && (
+          <button
+            onClick={() => { setSearchQuery(''); inputRef.current?.focus(); }}
+            className="p-2 mr-0.5 text-content-disabled hover:text-content-secondary
+                       dark:text-gray-500 dark:hover:text-gray-300 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+
+        {/* 검색 버튼 */}
+        <button
+          onClick={handleSearch}
+          disabled={isSearching || !searchQuery.trim()}
+          className="px-4 py-3 text-sm font-semibold
+                     bg-primary dark:bg-accent text-white
+                     hover:bg-primary-dark dark:hover:bg-accent-dark
+                     disabled:opacity-40 transition-colors"
+        >
+          검색
+        </button>
+      </div>
+
+      {/* 최근 검색어 드롭다운 */}
+      {showRecent && recentSearches.length > 0 && (
+        <div className="absolute top-full left-0 right-0 mt-2 z-50
+                        bg-white/95 dark:bg-dark-surface2/95 backdrop-blur-lg
+                        rounded-2xl shadow-lg
+                        border border-gray-100 dark:border-dark-border overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-2.5
+                          border-b border-gray-100 dark:border-dark-border">
+            <span className="text-xs font-medium text-content-secondary dark:text-gray-400">최근 검색</span>
+            <button onClick={clearAll} className="text-xs text-content-disabled hover:text-red-500 transition-colors">
+              전체 삭제
+            </button>
+          </div>
+          {recentSearches.map((q, i) => (
+            <button
+              key={i}
+              onClick={() => handleRecentClick(q)}
+              className="w-full flex items-center justify-between px-4 py-2.5 text-sm
+                         text-content-primary dark:text-white
+                         hover:bg-gray-50 dark:hover:bg-dark-surface3 transition-colors"
+            >
+              <div className="flex items-center gap-2.5">
+                <svg className="w-4 h-4 text-content-disabled" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                        d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span>{q}</span>
+              </div>
+              <span onClick={(e) => removeRecent(e, q)}
+                    className="text-content-disabled hover:text-red-500 p-1 rounded-full
+                               hover:bg-red-50 dark:hover:bg-red-900/20 transition-all">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/map/PlaceDetailCard.jsx
+++ b/src/components/map/PlaceDetailCard.jsx
@@ -1,0 +1,269 @@
+import React, { useState } from 'react';
+import { getDirectionsUrl, DUMMY_REVIEWS, CATEGORY_EMOJI_MAP } from '../../utils/mapConstants';
+
+/**
+ * 장소 상세 카드 — 구글맵/카카오맵 스타일
+ * 액션 버튼 아이콘 행 + 길찾기 + 리뷰
+ */
+export default function PlaceDetailCard({
+  place,
+  onClose,
+  isFavorite,
+  onToggleFavorite,
+  reviews: propReviews,
+}) {
+  const [showReviewForm, setShowReviewForm] = useState(false);
+  const [reviewForm, setReviewForm] = useState({ userName: '', rating: 5, content: '' });
+  const [reviews, setReviews] = useState(propReviews || DUMMY_REVIEWS);
+  const [copied, setCopied] = useState(false);
+
+  if (!place) return null;
+
+  const emoji = CATEGORY_EMOJI_MAP[
+    Object.keys(CATEGORY_EMOJI_MAP).find(k => place.category_name?.includes(k))
+  ] || '📍';
+
+  const categoryShort = place.category_name?.split(' > ').pop() || '';
+
+  const avgRating = reviews.length > 0
+    ? (reviews.reduce((s, r) => s + r.rating, 0) / reviews.length).toFixed(1) : '0';
+
+  const copyAddress = async () => {
+    try {
+      await navigator.clipboard.writeText(place.address_name);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {}
+  };
+
+  const handleShare = async () => {
+    const shareData = { title: place.place_name, text: `${place.place_name} - ${place.address_name}`, url: place.place_url || window.location.href };
+    try {
+      if (navigator.share) await navigator.share(shareData);
+      else { await navigator.clipboard.writeText(`${shareData.title}\n${shareData.text}`); alert('링크가 복사되었습니다!'); }
+    } catch {}
+  };
+
+  const handleSubmitReview = () => {
+    if (!reviewForm.content.trim()) return;
+    setReviews(prev => [{
+      id: Date.now(), userName: reviewForm.userName || '익명',
+      rating: reviewForm.rating, content: reviewForm.content,
+      date: new Date().toISOString().split('T')[0],
+    }, ...prev]);
+    setReviewForm({ userName: '', rating: 5, content: '' });
+    setShowReviewForm(false);
+  };
+
+  const Stars = ({ rating, interactive, onChange, size = 'text-base' }) => (
+    <div className="flex gap-0.5">
+      {[1, 2, 3, 4, 5].map(s => (
+        <button key={s} type="button" disabled={!interactive}
+          onClick={() => interactive && onChange?.(s)}
+          className={`${size} ${interactive ? 'cursor-pointer' : 'cursor-default'}
+                      ${s <= rating ? 'text-yellow-400' : 'text-gray-200 dark:text-gray-600'}`}>
+          ★
+        </button>
+      ))}
+    </div>
+  );
+
+  // 액션 버튼 (구글맵 스타일)
+  const ActionButton = ({ icon, label, onClick, href, highlight }) => {
+    const cls = `flex flex-col items-center gap-1.5 min-w-[3.5rem]`;
+    const iconCls = `w-10 h-10 rounded-full flex items-center justify-center text-base transition-all
+                     ${highlight
+                       ? 'bg-primary dark:bg-accent text-white'
+                       : 'bg-gray-100 dark:bg-dark-surface3 text-content-primary dark:text-white hover:bg-gray-200 dark:hover:bg-dark-border'
+                     }`;
+    const inner = (<><div className={iconCls}>{icon}</div><span className="text-[10px] text-content-secondary dark:text-gray-400">{label}</span></>);
+    if (href) return <a href={href} target="_blank" rel="noopener noreferrer" className={cls}>{inner}</a>;
+    return <button onClick={onClick} className={cls}>{inner}</button>;
+  };
+
+  return (
+    <div className="h-full flex flex-col bg-white dark:bg-dark-surface2 overflow-hidden">
+      {/* ── 헤더 ── */}
+      <div className="relative p-4 pb-3">
+        {/* 닫기 */}
+        <button onClick={onClose}
+          className="absolute top-3 right-3 p-2 rounded-full bg-gray-100/80 dark:bg-dark-surface3/80
+                     hover:bg-gray-200 dark:hover:bg-dark-border transition-colors z-10">
+          <svg className="w-4 h-4 text-content-secondary dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        {/* 장소명 + 카테고리 */}
+        <div className="flex items-start gap-3 pr-10">
+          <div className="w-12 h-12 rounded-2xl bg-primary/10 dark:bg-accent/15
+                          flex items-center justify-center text-2xl flex-shrink-0">
+            {emoji}
+          </div>
+          <div className="min-w-0">
+            <h2 className="text-lg font-extrabold text-content-primary dark:text-white leading-tight">
+              {place.place_name}
+            </h2>
+            <div className="flex items-center gap-2 mt-1">
+              {categoryShort && (
+                <span className="text-[11px] px-2 py-0.5 rounded-full
+                                 bg-primary/10 dark:bg-accent/15 text-primary dark:text-accent font-medium">
+                  {categoryShort}
+                </span>
+              )}
+              <div className="flex items-center gap-1">
+                <span className="text-yellow-400 text-xs">★</span>
+                <span className="text-xs font-bold text-content-primary dark:text-white">{avgRating}</span>
+                <span className="text-[11px] text-content-disabled">({reviews.length})</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── 컨텐츠 (스크롤) ── */}
+      <div className="flex-1 overflow-y-auto">
+        {/* 액션 버튼 행 (구글맵 스타일) */}
+        <div className="flex items-start justify-around px-4 py-3 border-y border-gray-100 dark:border-dark-border">
+          <ActionButton icon="📞" label="전화" href={place.phone ? `tel:${place.phone}` : undefined}
+                        onClick={!place.phone ? () => alert('전화번호가 없습니다') : undefined} />
+          <ActionButton icon="🗺️" label="길찾기" href={getDirectionsUrl(place, 'kakao')} highlight />
+          <ActionButton icon={isFavorite ? '❤️' : '🤍'} label={isFavorite ? '저장됨' : '저장'}
+                        onClick={() => onToggleFavorite(place)} />
+          <ActionButton icon="📤" label="공유" onClick={handleShare} />
+        </div>
+
+        {/* 정보 섹션 */}
+        <div className="px-4 py-3 space-y-3">
+          {/* 주소 */}
+          <div className="flex items-start gap-3">
+            <svg className="w-[18px] h-[18px] mt-0.5 text-content-secondary dark:text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-content-primary dark:text-gray-300">{place.road_address_name || place.address_name}</p>
+              {place.road_address_name && place.address_name !== place.road_address_name && (
+                <p className="text-[11px] text-content-disabled dark:text-gray-500 mt-0.5">(지번) {place.address_name}</p>
+              )}
+              <button onClick={copyAddress}
+                      className="text-[11px] text-primary dark:text-accent hover:underline mt-0.5 font-medium">
+                {copied ? '✓ 복사됨' : '주소 복사'}
+              </button>
+            </div>
+          </div>
+
+          {/* 전화 */}
+          {place.phone && (
+            <div className="flex items-center gap-3">
+              <svg className="w-[18px] h-[18px] text-content-secondary dark:text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                      d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+              </svg>
+              <a href={`tel:${place.phone}`} className="text-sm text-primary dark:text-accent hover:underline font-medium">
+                {place.phone}
+              </a>
+            </div>
+          )}
+
+          {/* 거리 */}
+          {place.distance && (
+            <div className="flex items-center gap-3">
+              <svg className="w-[18px] h-[18px] text-content-secondary dark:text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                      d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+              </svg>
+              <span className="text-sm text-content-primary dark:text-gray-300">
+                현재 위치에서 {Number(place.distance) >= 1000
+                  ? `${(Number(place.distance) / 1000).toFixed(1)}km`
+                  : `${place.distance}m`}
+              </span>
+            </div>
+          )}
+
+          {/* 길찾기 버튼들 */}
+          <div className="flex gap-2 pt-1">
+            <a href={getDirectionsUrl(place, 'kakao')} target="_blank" rel="noopener noreferrer"
+               className="flex-1 flex items-center justify-center gap-1.5 py-2.5 rounded-xl text-sm font-semibold
+                          bg-primary dark:bg-accent text-white hover:opacity-90 transition-opacity">
+              <span>🗺️</span> 카카오 길찾기
+            </a>
+            <a href={getDirectionsUrl(place, 'naver')} target="_blank" rel="noopener noreferrer"
+               className="flex-1 flex items-center justify-center gap-1.5 py-2.5 rounded-xl text-sm font-semibold
+                          bg-gray-100 dark:bg-dark-surface3 text-content-primary dark:text-white
+                          hover:bg-gray-200 dark:hover:bg-dark-border transition-colors">
+              <span>🧭</span> 네이버 지도
+            </a>
+          </div>
+        </div>
+
+        {/* ── 리뷰 섹션 ── */}
+        <div className="border-t border-gray-100 dark:border-dark-border mt-1">
+          <div className="flex items-center justify-between px-4 py-3">
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-bold text-content-primary dark:text-white">리뷰</h3>
+              <span className="text-xs text-content-disabled bg-gray-100 dark:bg-dark-surface3 px-1.5 py-0.5 rounded-full">
+                {reviews.length}
+              </span>
+            </div>
+            <button
+              onClick={() => setShowReviewForm(!showReviewForm)}
+              className="text-xs font-semibold text-primary dark:text-accent hover:underline">
+              {showReviewForm ? '취소' : '+ 리뷰 작성'}
+            </button>
+          </div>
+
+          {showReviewForm && (
+            <div className="px-4 pb-3 space-y-2.5">
+              <input type="text" placeholder="닉네임 (선택)"
+                value={reviewForm.userName}
+                onChange={(e) => setReviewForm(p => ({ ...p, userName: e.target.value }))}
+                className="w-full px-3 py-2 text-sm rounded-xl bg-gray-50 dark:bg-dark-surface3
+                           border border-gray-200 dark:border-dark-border
+                           text-content-primary dark:text-white
+                           focus:outline-none focus:ring-2 focus:ring-primary/30 dark:focus:ring-accent/30" />
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-content-secondary dark:text-gray-400">별점</span>
+                <Stars rating={reviewForm.rating} interactive onChange={(s) => setReviewForm(p => ({ ...p, rating: s }))} />
+              </div>
+              <textarea placeholder="리뷰를 작성해주세요"
+                value={reviewForm.content}
+                onChange={(e) => setReviewForm(p => ({ ...p, content: e.target.value }))}
+                rows={3}
+                className="w-full px-3 py-2 text-sm rounded-xl bg-gray-50 dark:bg-dark-surface3
+                           border border-gray-200 dark:border-dark-border
+                           text-content-primary dark:text-white resize-none
+                           focus:outline-none focus:ring-2 focus:ring-primary/30 dark:focus:ring-accent/30" />
+              <button onClick={handleSubmitReview}
+                className="w-full py-2.5 rounded-xl text-sm font-semibold bg-primary dark:bg-accent text-white
+                           hover:opacity-90 transition-opacity">
+                등록
+              </button>
+            </div>
+          )}
+
+          <div className="px-4 pb-4 space-y-2.5">
+            {reviews.map(r => (
+              <div key={r.id} className="p-3.5 rounded-2xl bg-gray-50 dark:bg-dark-surface3">
+                <div className="flex items-center justify-between mb-1.5">
+                  <div className="flex items-center gap-2">
+                    <div className="w-6 h-6 rounded-full bg-primary/10 dark:bg-accent/15
+                                    flex items-center justify-center text-[10px] font-bold
+                                    text-primary dark:text-accent">
+                      {r.userName.charAt(0)}
+                    </div>
+                    <span className="text-sm font-semibold text-content-primary dark:text-white">{r.userName}</span>
+                  </div>
+                  <span className="text-[11px] text-content-disabled dark:text-gray-500">{r.date}</span>
+                </div>
+                <Stars rating={r.rating} size="text-xs" />
+                <p className="mt-1.5 text-sm text-content-secondary dark:text-gray-300 leading-relaxed">{r.content}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/map/PlaceListPanel.jsx
+++ b/src/components/map/PlaceListPanel.jsx
@@ -1,0 +1,262 @@
+import React, { useState, useRef, useCallback } from 'react';
+import { CATEGORY_EMOJI_MAP } from '../../utils/mapConstants';
+
+/**
+ * 장소 목록 패널
+ * 데스크톱: 우측 사이드 패널 (w-80)
+ * 모바일: 바텀시트 (peek → half → full) — 구글맵/네이버맵 스타일
+ */
+export default function PlaceListPanel({
+  locations,
+  selectedPlace,
+  onPlaceClick,
+  isFavorite,
+  onToggleFavorite,
+  showFavorites,
+  favorites,
+  onToggleShowFavorites,
+  sortBy = 'distance',
+  onSortChange,
+}) {
+  const [sheetState, setSheetState] = useState('collapsed');
+  const dragStartRef = useRef(null);
+
+  const displayList = showFavorites ? favorites : locations;
+
+  // 터치 드래그
+  const handleTouchStart = useCallback((e) => {
+    dragStartRef.current = e.touches[0].clientY;
+  }, []);
+
+  const handleTouchEnd = useCallback((e) => {
+    if (dragStartRef.current === null) return;
+    const delta = dragStartRef.current - e.changedTouches[0].clientY;
+    dragStartRef.current = null;
+    if (delta > 40) setSheetState(prev => prev === 'collapsed' ? 'half' : 'full');
+    else if (delta < -40) setSheetState(prev => prev === 'full' ? 'half' : 'collapsed');
+  }, []);
+
+  const sheetHeightClass = {
+    collapsed: 'h-[4.5rem]',
+    half: 'h-[45vh]',
+    full: 'h-[85vh]',
+  }[sheetState];
+
+  const getEmoji = (place) => {
+    const key = Object.keys(CATEGORY_EMOJI_MAP).find(k => place.category_name?.includes(k));
+    return CATEGORY_EMOJI_MAP[key] || '📍';
+  };
+
+  // 거리 표시 (m → km)
+  const formatDistance = (d) => {
+    if (!d) return '';
+    const m = Number(d);
+    return m >= 1000 ? `${(m / 1000).toFixed(1)}km` : `${m}m`;
+  };
+
+  // ── 장소 카드 ──
+  const PlaceCard = ({ place }) => {
+    const isActive = selectedPlace?.id === place.id;
+    const fav = typeof isFavorite === 'function' ? isFavorite(place.id) : false;
+
+    return (
+      <button
+        onClick={() => onPlaceClick(place)}
+        className={`w-full text-left p-3 rounded-2xl transition-all duration-200 group
+                    ${isActive
+                      ? 'bg-primary/8 dark:bg-accent/10 ring-1 ring-primary/20 dark:ring-accent/20'
+                      : 'hover:bg-gray-50 dark:hover:bg-dark-surface3'
+                    }`}
+      >
+        <div className="flex items-start gap-3">
+          {/* 이모지 아이콘 */}
+          <div className={`w-11 h-11 rounded-xl flex items-center justify-center text-lg flex-shrink-0
+                          ${isActive
+                            ? 'bg-primary/15 dark:bg-accent/15'
+                            : 'bg-gray-100 dark:bg-dark-surface3 group-hover:bg-gray-200 dark:group-hover:bg-dark-border'
+                          } transition-colors`}>
+            {getEmoji(place)}
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5">
+              <h3 className="text-sm font-bold text-content-primary dark:text-white truncate">
+                {place.place_name}
+              </h3>
+              {place.distance && (
+                <span className="text-[11px] text-primary dark:text-accent font-medium flex-shrink-0">
+                  {formatDistance(place.distance)}
+                </span>
+              )}
+            </div>
+
+            {/* 카테고리 + 별점 인라인 */}
+            <div className="flex items-center gap-1.5 mt-0.5">
+              {place.category_name && (
+                <span className="text-[11px] text-content-secondary dark:text-gray-400 truncate">
+                  {place.category_name.split(' > ').pop()}
+                </span>
+              )}
+              {place.rating && (
+                <>
+                  <span className="text-content-disabled">·</span>
+                  <span className="text-[11px] text-yellow-500 font-medium">
+                    ★ {Number(place.rating).toFixed(1)}
+                  </span>
+                </>
+              )}
+            </div>
+
+            <p className="text-[11px] text-content-disabled dark:text-gray-500 truncate mt-0.5">
+              {place.road_address_name || place.address_name}
+            </p>
+          </div>
+
+          {/* 즐겨찾기 */}
+          <button
+            onClick={(e) => { e.stopPropagation(); onToggleFavorite(place); }}
+            className="p-1.5 flex-shrink-0 rounded-full hover:bg-gray-100 dark:hover:bg-dark-surface3 transition-colors"
+          >
+            <span className="text-sm">{fav ? '❤️' : '🤍'}</span>
+          </button>
+        </div>
+      </button>
+    );
+  };
+
+  // ── 빈 상태 ──
+  const EmptyState = () => (
+    <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+      <div className="w-16 h-16 rounded-full bg-gray-100 dark:bg-dark-surface3 flex items-center justify-center mb-4">
+        <span className="text-3xl">{showFavorites ? '💝' : '🐕'}</span>
+      </div>
+      <p className="text-sm font-bold text-content-primary dark:text-white mb-1">
+        {showFavorites ? '즐겨찾기가 없어요' : '주변 장소가 없어요'}
+      </p>
+      <p className="text-xs text-content-secondary dark:text-gray-400 leading-relaxed">
+        {showFavorites ? '마음에 드는 장소를 ❤️ 눌러 저장해보세요' : '카테고리를 선택하거나\n지역을 검색해보세요'}
+      </p>
+    </div>
+  );
+
+  // ── 헤더 ──
+  const PanelHeader = ({ className = '' }) => (
+    <div className={`flex items-center justify-between px-4 py-3 ${className}`}>
+      <div className="flex items-center gap-2">
+        <h2 className="text-sm font-bold text-content-primary dark:text-white">
+          {showFavorites ? '즐겨찾기' : '주변 장소'}
+        </h2>
+        <span className="text-xs text-content-secondary dark:text-gray-400 bg-gray-100 dark:bg-dark-surface3 px-2 py-0.5 rounded-full">
+          {displayList.length}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        {/* 정렬 (거리/이름) */}
+        {!showFavorites && onSortChange && locations.length > 0 && (
+          <select
+            value={sortBy}
+            onChange={(e) => onSortChange(e.target.value)}
+            className="text-[11px] bg-transparent text-content-secondary dark:text-gray-400
+                       border-none focus:outline-none cursor-pointer"
+          >
+            <option value="distance">거리순</option>
+            <option value="name">이름순</option>
+          </select>
+        )}
+        {/* 즐겨찾기 토글 */}
+        <button
+          onClick={onToggleShowFavorites}
+          className={`flex items-center gap-1 text-xs px-2.5 py-1.5 rounded-full transition-all
+                      ${showFavorites
+                        ? 'bg-red-50 dark:bg-red-900/20 text-red-500 font-medium'
+                        : 'text-content-secondary dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-dark-surface3'
+                      }`}
+        >
+          <span className="text-sm">❤️</span>
+          <span>{showFavorites ? '목록' : favorites.length}</span>
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      {/* ═══ 데스크톱: 사이드 패널 ═══ */}
+      <div className="hidden md:flex flex-col w-80 h-full
+                       bg-white dark:bg-dark-surface2
+                       border-l border-gray-100 dark:border-dark-border">
+        <PanelHeader className="border-b border-gray-100 dark:border-dark-border" />
+        <div className="flex-1 overflow-y-auto p-2 space-y-0.5">
+          {displayList.length === 0 ? <EmptyState /> : (
+            displayList.map((place) => <PlaceCard key={place.id} place={place} />)
+          )}
+        </div>
+      </div>
+
+      {/* ═══ 모바일: 바텀시트 ═══ */}
+      <div
+        className={`md:hidden fixed bottom-0 left-0 right-0 z-30
+                    bg-white dark:bg-dark-surface2
+                    rounded-t-2xl shadow-[0_-4px_20px_rgba(0,0,0,0.1)] dark:shadow-[0_-4px_20px_rgba(0,0,0,0.4)]
+                    transition-all duration-300 ease-out
+                    ${sheetHeightClass}`}
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      >
+        {/* 드래그 핸들 */}
+        <div
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+          onClick={() => setSheetState(prev => prev === 'collapsed' ? 'half' : 'collapsed')}
+          className="cursor-grab active:cursor-grabbing"
+        >
+          <div className="flex justify-center pt-2.5 pb-1">
+            <div className="w-9 h-1 rounded-full bg-gray-300 dark:bg-gray-600" />
+          </div>
+
+          {/* peek 상태: 첫 번째 장소 미리보기 (구글맵 스타일) */}
+          {sheetState === 'collapsed' ? (
+            <div className="px-4 pb-2">
+              {displayList.length > 0 ? (
+                <div className="flex items-center gap-3">
+                  <div className="w-9 h-9 rounded-lg bg-gray-100 dark:bg-dark-surface3 flex items-center justify-center text-base">
+                    {getEmoji(displayList[0])}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-bold text-content-primary dark:text-white truncate">
+                      {displayList[0].place_name}
+                    </p>
+                    <p className="text-[11px] text-content-secondary dark:text-gray-400">
+                      {showFavorites ? `❤️ 즐겨찾기 ${favorites.length}개` : `${locations.length}개 장소`}
+                      {displayList[0].distance && ` · ${formatDistance(displayList[0].distance)}`}
+                    </p>
+                  </div>
+                  <svg className="w-4 h-4 text-content-disabled" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                  </svg>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <span className="text-base">🐾</span>
+                  <span className="text-sm text-content-secondary dark:text-gray-400">
+                    카테고리를 선택하거나 검색해보세요
+                  </span>
+                </div>
+              )}
+            </div>
+          ) : (
+            <PanelHeader />
+          )}
+        </div>
+
+        {/* 리스트 */}
+        {sheetState !== 'collapsed' && (
+          <div className="flex-1 overflow-y-auto px-2 pb-3 space-y-0.5">
+            {displayList.length === 0 ? <EmptyState /> : (
+              displayList.map((place) => <PlaceCard key={place.id} place={place} />)
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/containers/map/KakaoMapContainer.jsx
+++ b/src/containers/map/KakaoMapContainer.jsx
@@ -1,126 +1,54 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '../../contexts/ThemeProvider';
+import useFavorites from '../../hooks/map/useFavorites';
+import {
+  CATEGORIES,
+  CATEGORY_EMOJI_MAP,
+  DEFAULT_LOCATION,
+  ZOOM_RADIUS_MAP,
+  LS_KEYS,
+  DUMMY_REVIEWS,
+} from '../../utils/mapConstants';
 import KakaoMapView from '../../components/map/KakaoMapView';
 
-// 한국 행정구역 데이터
-export const koreaLocations = {
-  서울: {
-    강남구: ['청담동', '삼성동', '역삼동'],
-    강서구: ['화곡동', '등촌동', '목동'],
-    종로구: ['종로1가', '종로2가', '종로3가']
-  },
-  부산: {
-    해운대구: ['우동', 'Left', '중동'],
-    남구: ['용호동', '감만동', '문현동'],
-    동래구: ['명륜동', '온천동', '사직동']
-  },
-  대구: {
-    달서구: ['성당동', '두류동', '월성동'],
-    중구: ['봉산동', '대신동', '남산동']
-  }
-};
-
-// 카테고리 정의
-const categories = {
-  petShop: '애견샵',
-  animalHospital: '동물병원',
-  petCafe: '애견카페',
-  dogPark: '강아지 공원',
-  dogHotel: '강아지 호텔'
-};
-
-// 카테고리별 아이콘 매핑
-const categoryIcons = {
-  '애견샵': 'marker/shop',
-  '동물병원': 'marker/hospital',
-  '애견카페': 'marker/cafe',
-  '강아지 공원': 'marker/park',
-  '강아지 호텔': 'marker/hotel'
-};
-
-// 더미 리뷰 데이터
-const getDummyReviews = (placeName) => {
-  // 실제 구현에서는 API 호출로 대체될 부분
-  const reviews = [
-    {
-      id: 1,
-      userName: '강아지러버',
-      rating: 5,
-      content: '정말 좋은 곳이에요! 강아지와 함께 편안하게 시간을 보낼 수 있었습니다.',
-      date: '2023-05-15'
-    },
-    {
-      id: 2,
-      userName: '멍멍이맘',
-      rating: 4,
-      content: '직원분들이 친절하고 시설도 깨끗해요. 다음에 또 방문할 예정입니다.',
-      date: '2023-06-20'
-    },
-    {
-      id: 3,
-      userName: '포메러브',
-      rating: 3,
-      content: '괜찮은 곳이지만 주차가 조금 불편해요.',
-      date: '2023-07-10'
-    }
-  ];
-  
-  return reviews;
-};
-
+/**
+ * 카카오맵 컨테이너 — 비즈니스 로직 + 훅 조합
+ * View에 props 전달
+ */
 const KakaoMapContainer = () => {
+  const { isDark } = useTheme();
   const mapContainerRef = useRef(null);
   const mapRef = useRef(null);
-  const currentLocationMarker = useRef(null);
+  const currentLocationMarkerRef = useRef(null);
   const markersRef = useRef([]);
   const customOverlaysRef = useRef([]);
 
-  // 지역 검색 관련 상태
+  // --- 상태 ---
   const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
-
-  // 지도 및 장소 관련 상태
   const [locations, setLocations] = useState([]);
   const [selectedPlace, setSelectedPlace] = useState(null);
   const [currentLocation, setCurrentLocation] = useState(null);
   const [selectedCategory, setSelectedCategory] = useState(() => {
-    const savedCategory = localStorage.getItem('lastSelectedCategory');
-    return savedCategory || categories.petShop;
+    return localStorage.getItem(LS_KEYS.LAST_CATEGORY) || CATEGORIES[0].keyword;
   });
   const [isLoadingLocation, setIsLoadingLocation] = useState(false);
-  const [locationError, setLocationError] = useState(null);
-  
-  // 리뷰 관련 상태
   const [reviews, setReviews] = useState([]);
-  const [newReview, setNewReview] = useState({ userName: '', rating: 5, content: '' });
-  const [showReviewForm, setShowReviewForm] = useState(false);
+  const [mapReady, setMapReady] = useState(false);
+  const [showResearch, setShowResearch] = useState(false);
 
-  const isMobile = useMediaQuery('(max-width: 768px)');
+  // 즐겨찾기
+  const { favorites, isFavorite, toggleFavorite } = useFavorites();
+  const [showFavorites, setShowFavorites] = useState(false);
 
-  // 모바일: 오버레이(리스트) 열기 상태
-  const [openList, setOpenList] = useState(false);
-  const toggleList = () => setOpenList(prev => !prev);
-
-  // 모바일 상세정보 오버레이 열릴 때 배경 스크롤 차단
-  useEffect(() => {
-    if (isMobile && selectedPlace) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'auto';
-    }
-  }, [isMobile, selectedPlace]);
-
-  // 장소가 선택되면 리뷰 데이터 가져오기
+  // --- 리뷰 로드 ---
   useEffect(() => {
     if (selectedPlace) {
-      // 실제 구현에서는 API 요청으로 리뷰를 가져옵니다
-      const placeReviews = getDummyReviews(selectedPlace.name);
-      setReviews(placeReviews);
+      setReviews(DUMMY_REVIEWS);
     }
   }, [selectedPlace]);
 
-  // 카카오맵 스크립트 로드
+  // --- 카카오맵 스크립트 로드 ---
   useEffect(() => {
     const loadScript = (src) =>
       new Promise((resolve, reject) => {
@@ -140,10 +68,7 @@ const KakaoMapContainer = () => {
 
     loadScript(scriptSrc)
       .then(() => {
-        if (!window.kakao) {
-          console.error('Kakao script not loaded');
-          return;
-        }
+        if (!window.kakao) return;
         window.kakao.maps.load(() => {
           initializeMap();
         });
@@ -151,54 +76,41 @@ const KakaoMapContainer = () => {
       .catch((error) => {
         console.error('Kakao Map script load error:', error);
       });
+
+    return () => {
+      clearMarkers();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // --- 맵 초기화 ---
   const initializeMap = useCallback(() => {
-    const defaultLocation = { latitude: 37.5665, longitude: 126.9780 }; // 서울 시청
-    
-    // 사용자의 현재 위치를 먼저 확인합니다
     getUserCurrentLocation();
-    
-    // 기본적으로 서울 시청으로 시작하지만, 위치 정보가 얻어지면 업데이트됩니다
-    setCurrentLocation(defaultLocation);
-    loadMap(defaultLocation.latitude, defaultLocation.longitude);
+    setCurrentLocation(DEFAULT_LOCATION);
+    loadMap(DEFAULT_LOCATION.latitude, DEFAULT_LOCATION.longitude);
   }, []);
 
   const getUserCurrentLocation = () => {
-    if (!navigator.geolocation) {
-      setLocationError("현재 브라우저에서 위치 정보를 지원하지 않습니다");
-      return;
-    }
-
+    if (!navigator.geolocation) return;
     setIsLoadingLocation(true);
-    setLocationError(null);
 
     navigator.geolocation.getCurrentPosition(
       (position) => {
         const { latitude, longitude } = position.coords;
         setCurrentLocation({ latitude, longitude });
-        
-        // 현재 위치로 지도 이동 및 마커 표시
+
         if (mapRef.current) {
           const latlng = new window.kakao.maps.LatLng(latitude, longitude);
           mapRef.current.setCenter(latlng);
           updateCurrentLocationMarker(mapRef.current, latlng);
-          // 선택된 카테고리 유지하여 검색
           fetchLocations(mapRef.current, latitude, longitude, selectedCategory);
         }
-        
         setIsLoadingLocation(false);
       },
-      (error) => {
-        console.error("현재 위치를 가져오는데 실패했습니다:", error);
-        setLocationError("현재 위치를 가져오는데 실패했습니다. 권한을 확인해주세요.");
+      () => {
         setIsLoadingLocation(false);
       },
-      {
-        enableHighAccuracy: true,
-        timeout: 5000,
-        maximumAge: 0
-      }
+      { enableHighAccuracy: true, timeout: 5000, maximumAge: 0 }
     );
   };
 
@@ -214,771 +126,265 @@ const KakaoMapContainer = () => {
 
     const map = new window.kakao.maps.Map(mapContainerRef.current, mapOption);
     mapRef.current = map;
+    setMapReady(true);
 
-    // 지도 확대/축소 컨트롤 추가
-    const zoomControl = new window.kakao.maps.ZoomControl();
-    map.addControl(zoomControl, window.kakao.maps.ControlPosition.RIGHT);
-
-    // 지도 확대/축소 완료 이벤트
+    // 줌 변경
     window.kakao.maps.event.addListener(map, 'zoom_changed', () => {
-      // 줌 레벨이 변경되었을 때 현재 위치를 업데이트
       const center = map.getCenter();
       const newLat = center.getLat();
       const newLng = center.getLng();
-      
-      // 새 위치 설정
-      setCurrentLocation({
-        latitude: newLat,
-        longitude: newLng
-      });
-      
-      // 확대/축소 시 현재 보이는 영역에서 검색
+      setCurrentLocation({ latitude: newLat, longitude: newLng });
       clearMarkers();
       fetchLocations(map, newLat, newLng, selectedCategory);
     });
 
-    // 지도 클릭 이벤트 - 현재 위치 마커만 업데이트, 장소 마커는 생성하지 않음
+    // 클릭
     window.kakao.maps.event.addListener(map, 'click', (mouseEvent) => {
       const latlng = mouseEvent.latLng;
-      
-      // 선택된 장소가 있으면 닫기
       if (selectedPlace) {
         setSelectedPlace(null);
-        setShowReviewForm(false);
       }
-      
-      // 현재 위치 상태만 업데이트
-      setCurrentLocation({ 
-        latitude: latlng.getLat(), 
-        longitude: latlng.getLng() 
-      });
-      
-      // 현재 위치 마커만 이동
+      setCurrentLocation({ latitude: latlng.getLat(), longitude: latlng.getLng() });
       updateCurrentLocationMarker(map, latlng);
-      
-      // 클릭한 위치에서 새로 검색
       clearMarkers();
       fetchLocations(map, latlng.getLat(), latlng.getLng(), selectedCategory);
     });
 
-    // 지도 이동 완료 이벤트 - 위치만 업데이트하고 자동 검색은 하지 않음
+    // 드래그 → "이 지역 재검색" 버튼 표시 (네이버맵 스타일)
     window.kakao.maps.event.addListener(map, 'dragend', () => {
       const center = map.getCenter();
       const newLat = center.getLat();
       const newLng = center.getLng();
-      
-      // 현재 위치가 크게 변경된 경우에만 마커를 갱신
+
       if (currentLocation) {
         const latDiff = Math.abs(currentLocation.latitude - newLat);
         const lngDiff = Math.abs(currentLocation.longitude - newLng);
-        
-        // 위치가 일정 거리 이상 이동한 경우 갱신
-        if (latDiff > 0.01 || lngDiff > 0.01) {
-          clearMarkers();
-          // 위치 변경 후 주변 검색 실행
-          fetchLocations(map, newLat, newLng, selectedCategory);
+        if (latDiff > 0.005 || lngDiff > 0.005) {
+          setShowResearch(true);
         }
       }
-      
-      setCurrentLocation({ 
-        latitude: newLat, 
-        longitude: newLng 
-      });
+      setCurrentLocation({ latitude: newLat, longitude: newLng });
     });
 
-    // 현재 위치에 마커 표시
+    // 현재 위치 마커
     const currentLatLng = new window.kakao.maps.LatLng(lat, lng);
     updateCurrentLocationMarker(map, currentLatLng);
-    
-    // 모바일 환경을 위한 설정
-    if (isMobile) {
-      // 커스텀 줌 컨트롤 컨테이너 생성
-      const zoomControlContainer = document.createElement('div');
-      zoomControlContainer.className = 'custom-zoom-control';
-      zoomControlContainer.style.position = 'absolute';
-      zoomControlContainer.style.bottom = '80px';
-      zoomControlContainer.style.right = '10px';
-      zoomControlContainer.style.zIndex = '2';
-      zoomControlContainer.style.display = 'flex';
-      zoomControlContainer.style.flexDirection = 'column';
-      zoomControlContainer.style.padding = '5px';
-      
-      // 줌 인 버튼
-      const zoomInBtn = document.createElement('button');
-      zoomInBtn.innerHTML = '+';
-      zoomInBtn.style.width = '40px';
-      zoomInBtn.style.height = '40px';
-      zoomInBtn.style.backgroundColor = 'white';
-      zoomInBtn.style.border = '1px solid #ccc';
-      zoomInBtn.style.borderRadius = '50%';
-      zoomInBtn.style.fontSize = '20px';
-      zoomInBtn.style.fontWeight = 'bold';
-      zoomInBtn.style.margin = '5px';
-      zoomInBtn.style.boxShadow = '0 2px 5px rgba(0,0,0,0.3)';
-      
-      // 줌 아웃 버튼
-      const zoomOutBtn = document.createElement('button');
-      zoomOutBtn.innerHTML = '-';
-      zoomOutBtn.style.width = '40px';
-      zoomOutBtn.style.height = '40px';
-      zoomOutBtn.style.backgroundColor = 'white';
-      zoomOutBtn.style.border = '1px solid #ccc';
-      zoomOutBtn.style.borderRadius = '50%';
-      zoomOutBtn.style.fontSize = '20px';
-      zoomOutBtn.style.fontWeight = 'bold';
-      zoomOutBtn.style.margin = '5px';
-      zoomOutBtn.style.boxShadow = '0 2px 5px rgba(0,0,0,0.3)';
-      
-      // 내 위치 버튼
-      const myLocationBtn = document.createElement('button');
-      myLocationBtn.innerHTML = '📍';
-      myLocationBtn.style.width = '40px';
-      myLocationBtn.style.height = '40px';
-      myLocationBtn.style.backgroundColor = 'white';
-      myLocationBtn.style.border = '1px solid #ccc';
-      myLocationBtn.style.borderRadius = '50%';
-      myLocationBtn.style.fontSize = '20px';
-      myLocationBtn.style.margin = '5px';
-      myLocationBtn.style.boxShadow = '0 2px 5px rgba(0,0,0,0.3)';
-      
-      // 버튼 이벤트 추가
-      zoomInBtn.addEventListener('click', () => {
-        const currentLevel = map.getLevel();
-        map.setLevel(currentLevel - 1, {animate: true});
-      });
-      
-      zoomOutBtn.addEventListener('click', () => {
-        const currentLevel = map.getLevel();
-        map.setLevel(currentLevel + 1, {animate: true});
-      });
-      
-      myLocationBtn.addEventListener('click', () => {
-        getUserCurrentLocation();
-      });
-      
-      // 버튼을 컨테이너에 추가
-      zoomControlContainer.appendChild(zoomInBtn);
-      zoomControlContainer.appendChild(zoomOutBtn);
-      zoomControlContainer.appendChild(myLocationBtn);
-      
-      // 컨테이너를 지도에 추가
-      mapContainerRef.current.appendChild(zoomControlContainer);
-      
-      // 모바일 터치 이벤트 개선
-      const mapContainer = mapContainerRef.current;
-      let isDragging = false;
-      let lastTouchX, lastTouchY;
-      let touchStartTime = 0;
-      let initialDistance = 0;
-      
-      // 터치 시작 이벤트
-      mapContainer.addEventListener('touchstart', (e) => {
-        // 두 손가락 터치(핀치 줌)
-        if (e.touches.length === 2) {
-          const touch1 = e.touches[0];
-          const touch2 = e.touches[1];
-          initialDistance = Math.hypot(
-            touch2.clientX - touch1.clientX,
-            touch2.clientY - touch1.clientY
-          );
-        } 
-        // 한 손가락 터치(드래그)
-        else if (e.touches.length === 1) {
-          touchStartTime = Date.now();
-          isDragging = true;
-          lastTouchX = e.touches[0].clientX;
-          lastTouchY = e.touches[0].clientY;
-        }
-      });
-      
-      // 터치 이동 이벤트
-      mapContainer.addEventListener('touchmove', (e) => {
-        // 상세 정보 화면이 열려있는 경우는 스크롤만 허용
-        if (selectedPlace) return;
-        
-        // 핀치 줌(두 손가락)
-        if (e.touches.length === 2) {
-          const touch1 = e.touches[0];
-          const touch2 = e.touches[1];
-          const currentDistance = Math.hypot(
-            touch2.clientX - touch1.clientX,
-            touch2.clientY - touch1.clientY
-          );
-          
-          if (initialDistance > 0) {
-            if (currentDistance > initialDistance * 1.1) {
-              // 줌 인 (더 부드럽게)
-              const zoomFactor = Math.min(0.5, (currentDistance - initialDistance) / initialDistance);
-              const currentLevel = map.getLevel();
-              const newLevel = Math.max(1, currentLevel - zoomFactor * 2);
-              map.setLevel(newLevel);
-              initialDistance = currentDistance;
-            } else if (currentDistance < initialDistance * 0.9) {
-              // 줌 아웃 (더 부드럽게)
-              const zoomFactor = Math.min(0.5, (initialDistance - currentDistance) / initialDistance);
-              const currentLevel = map.getLevel();
-              const newLevel = Math.min(14, currentLevel + zoomFactor * 2);
-              map.setLevel(newLevel);
-              initialDistance = currentDistance;
-            }
-          }
-          
-          e.preventDefault();
-        } 
-        // 드래그(한 손가락)
-        else if (isDragging && e.touches.length === 1) {
-          const currentX = e.touches[0].clientX;
-          const currentY = e.touches[0].clientY;
-          
-          // 터치 이동 거리
-          const deltaX = lastTouchX - currentX;
-          const deltaY = lastTouchY - currentY;
-          
-          // 일정 거리 이상 이동 시에만 지도 이동 (작은 움직임 무시)
-          if (Math.abs(deltaX) > 1 || Math.abs(deltaY) > 1) {
-            // 더 빠른 이동 속도 적용
-            const currentTime = Date.now();
-            const timeElapsed = currentTime - touchStartTime;
-            // 빠른 움직임은 더 빠른 이동 속도
-            const speedFactor = timeElapsed < 250 ? 0.0004 : 0.0002;
-            
-            const currentCenter = map.getCenter();
-            const newLat = currentCenter.getLat() + (deltaY * speedFactor);
-            const newLng = currentCenter.getLng() - (deltaX * speedFactor);
-            map.setCenter(new window.kakao.maps.LatLng(newLat, newLng));
-            
-            // 위치 업데이트
-            lastTouchX = currentX;
-            lastTouchY = currentY;
-          }
-          
-          e.preventDefault();
-        }
-      }, { passive: false });
-      
-      // 터치 종료 이벤트
-      mapContainer.addEventListener('touchend', () => {
-        if (isDragging || initialDistance > 0) {
-          // 터치 종료 시 현재 위치 업데이트
-          const center = map.getCenter();
-          setCurrentLocation({
-            latitude: center.getLat(),
-            longitude: center.getLng()
-          });
-          
-          // 드래그 후 주변 검색 실행
-          fetchLocations(
-            map,
-            center.getLat(),
-            center.getLng(),
-            selectedCategory
-          );
-        }
-        
-        // 상태 초기화
-        isDragging = false;
-        initialDistance = 0;
-      });
-    }
+
+    // 초기 검색
+    fetchLocations(map, lat, lng, selectedCategory);
   };
 
-  // 현재 위치 마커 업데이트 - 검색된 장소와 구분되는 현재 위치 표시용 마커
+  // --- 현재 위치 마커 ---
   const updateCurrentLocationMarker = (map, latlng) => {
-      if (currentLocationMarker.current) {
-        currentLocationMarker.current.setPosition(latlng);
-      } else {
-        const marker = new window.kakao.maps.Marker({
-          map,
-          position: latlng,
-        title: "현재 위치",
-          image: new window.kakao.maps.MarkerImage(
-            "http://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_blue.png",
-            new window.kakao.maps.Size(24, 35),
-            { offset: new window.kakao.maps.Point(12, 35) }
-          ),
-        });
-        currentLocationMarker.current = marker;
-      }
-  };
-
-  // 커스텀 오버레이를 사용한 예쁜 마커 생성 함수
-  const createCustomMarker = (map, place) => {
-    try {
-      // 유효한 장소 데이터인지 확인
-      if (!place || !place.y || !place.x) {
-        console.error('유효하지 않은 장소 데이터:', place);
-        return null;
-      }
-      
-      // 이미 존재하는 오버레이인지 확인하여 중복 생성 방지
-      const isDuplicate = customOverlaysRef.current.some(overlay => {
-        if (overlay && overlay.getPosition) {
-          const pos = overlay.getPosition();
-          // 같은 위치의 오버레이가 이미 있는 경우
-          return pos && 
-            Math.abs(pos.getLat() - place.y) < 0.0001 && 
-            Math.abs(pos.getLng() - place.x) < 0.0001;
-        }
-        return false;
-      });
-      
-      if (isDuplicate) {
-        console.log('중복된 마커가 감지되어 생성이 취소되었습니다:', place.place_name);
-        return null;
-      }
-      
-      // 평균 별점 계산 (실제로는 DB에서 가져올 값)
-      const rating = Math.random() * 2 + 3; // 3~5점 사이 랜덤값
-      const ratingStr = rating.toFixed(1);
-      
-      // 장소 카테고리에 맞는 아이콘 결정
-      let iconType = 'marker/default'; // 기본값
-      
-      // 카테고리 이름에서 적절한 아이콘 찾기
-      if (place.category_name) {
-        for (const [category, icon] of Object.entries(categoryIcons)) {
-          if (place.category_name.includes(category)) {
-            iconType = icon;
-            break;
-          }
-        }
-      }
-      
-      // 커스텀 오버레이 내용 생성
-      const content = document.createElement('div');
-      content.className = 'custom-marker';
-      content.style.position = 'relative';
-      content.style.width = '60px';
-      content.style.height = '60px';
-      content.style.display = 'flex';
-      content.style.flexDirection = 'column';
-      content.style.alignItems = 'center';
-      content.style.cursor = 'pointer';
-      
-      // 마커 본체 (원형)
-      const markerBody = document.createElement('div');
-      markerBody.style.width = '40px';
-      markerBody.style.height = '40px';
-      markerBody.style.backgroundImage = `url(${process.env.PUBLIC_URL}/images/${iconType}.png)`;
-      markerBody.style.backgroundSize = 'cover';
-      markerBody.style.backgroundPosition = 'center';
-      markerBody.style.backgroundRepeat = 'no-repeat';
-      markerBody.style.backgroundColor = '#fff';
-      markerBody.style.borderRadius = '50%';
-      markerBody.style.boxShadow = '0 2px 6px rgba(0,0,0,0.3)';
-      markerBody.style.border = '2px solid #fff';
-      markerBody.style.transition = 'transform 0.2s ease';
-      content.appendChild(markerBody);
-      
-      // 별점 표시
-      const ratingDiv = document.createElement('div');
-      ratingDiv.style.marginTop = '2px';
-      ratingDiv.style.padding = '1px 5px';
-      ratingDiv.style.backgroundColor = '#4caf50';
-      ratingDiv.style.color = 'white';
-      ratingDiv.style.fontSize = '10px';
-      ratingDiv.style.fontWeight = 'bold';
-      ratingDiv.style.borderRadius = '10px';
-      ratingDiv.style.boxShadow = '0 1px 3px rgba(0,0,0,0.2)';
-      ratingDiv.innerHTML = `★ ${ratingStr}`;
-      content.appendChild(ratingDiv);
-      
-      // 커스텀 오버레이 생성
-      const position = new window.kakao.maps.LatLng(place.y, place.x);
-      const customOverlay = new window.kakao.maps.CustomOverlay({
-        position: position,
-        content: content,
-        yAnchor: 1.0,
-        zIndex: 1
-      });
-      
-      // 클릭 이벤트
-      content.onclick = function() {
-        // 카테고리에서 맞는 이름 찾기
-        let categoryKey = '';
-        Object.entries(categories).forEach(([key, value]) => {
-          if (place.category_name && place.category_name.includes(value)) {
-            categoryKey = key;
-          }
-        });
-        
-        setSelectedPlace({
-          id: place.id,
-          name: place.place_name,
-          address: place.address_name,
-          image: place.image_url,
-          position: { lat: place.y, lng: place.x },
-          phone: place.phone,
-          category_name: place.category_name,
-          place_url: place.place_url,
-          rating: ratingStr,
-          category_key: categoryKey,
-          icon_type: iconType
-        });
-        mapRef.current.setCenter(position);
-      };
-      
-      // 마우스 오버/아웃 효과
-      content.onmouseover = function() {
-        markerBody.style.transform = 'scale(1.1)';
-      };
-      
-      content.onmouseout = function() {
-        markerBody.style.transform = 'scale(1)';
-      };
-      
-      // 오버레이를 맵에 추가
-      customOverlay.setMap(map);
-      console.log(`마커 생성됨: ${place.place_name} (${place.category_name || '분류 없음'})`);
-      return customOverlay;
-    } catch (error) {
-      console.error('마커 생성 중 오류 발생:', error);
-      return null;
+    if (currentLocationMarkerRef.current) {
+      currentLocationMarkerRef.current.setPosition(latlng);
+      return;
     }
-  };
-
-  const clearMarkers = () => {
-    // 기존 마커 제거
-    markersRef.current.forEach((marker) => marker.setMap(null));
-    markersRef.current = [];
-    
-    // 커스텀 오버레이 제거
-    customOverlaysRef.current.forEach((overlay) => {
-      if (overlay && typeof overlay.setMap === 'function') {
-        overlay.setMap(null);
-      }
+    const markerImage = new window.kakao.maps.MarkerImage(
+      'http://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_blue.png',
+      new window.kakao.maps.Size(24, 35)
+    );
+    const marker = new window.kakao.maps.Marker({
+      map,
+      position: latlng,
+      image: markerImage,
     });
+    currentLocationMarkerRef.current = marker;
+  };
+
+  // --- 마커 관리 ---
+  const clearMarkers = () => {
+    customOverlaysRef.current.forEach(o => o.setMap(null));
     customOverlaysRef.current = [];
-    
-    console.log('모든 마커와 오버레이가 초기화되었습니다.');
+    markersRef.current.forEach(m => m.setMap(null));
+    markersRef.current = [];
   };
 
-  const fetchLocations = (map, lat, lng, keyword) => {
-    try {
-      // 먼저 기존 마커들을 모두 제거
-    clearMarkers();
-    setLocations([]);
-      
-      if (!keyword) {
-        console.warn('검색 키워드가 없어 검색을 중단합니다.');
-        return;
-      }
-      
-      console.log(`"${keyword}" 키워드로 위치(${lat.toFixed(6)}, ${lng.toFixed(6)}) 주변 검색 시작`);
-      
+  const createCustomMarker = (map, place) => {
+    // 중복 방지
+    if (customOverlaysRef.current.some(o => o.placeId === place.id)) return;
+
+    const emoji = CATEGORY_EMOJI_MAP[
+      Object.keys(CATEGORY_EMOJI_MAP).find(k => place.category_name?.includes(k))
+    ] || '📍';
+
+    const rating = (Math.random() * 2 + 3).toFixed(1);
+
+    const content = document.createElement('div');
+    content.style.cssText = `
+      cursor: pointer; display: flex; flex-direction: column; align-items: center;
+      transform: translateY(-20px);
+    `;
+    content.innerHTML = `
+      <div style="
+        width: 40px; height: 40px; border-radius: 50%;
+        background: ${isDark ? '#252525' : '#fff'};
+        border: 2px solid ${isDark ? '#4CAF50' : '#8B5E3C'};
+        display: flex; align-items: center; justify-content: center;
+        font-size: 18px; box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+        transition: transform 0.2s;
+      ">${emoji}</div>
+      <div style="
+        margin-top: 2px; padding: 1px 6px; border-radius: 8px;
+        background: ${isDark ? '#4CAF50' : '#8B5E3C'}; color: #fff;
+        font-size: 10px; font-weight: bold; white-space: nowrap;
+      ">⭐ ${rating}</div>
+    `;
+
+    content.addEventListener('click', () => {
+      setSelectedPlace({ ...place, rating: Number(rating) });
+      map.panTo(new window.kakao.maps.LatLng(place.y, place.x));
+    });
+
+    content.addEventListener('mouseenter', () => {
+      content.firstElementChild.style.transform = 'scale(1.15)';
+    });
+    content.addEventListener('mouseleave', () => {
+      content.firstElementChild.style.transform = 'scale(1)';
+    });
+
+    const overlay = new window.kakao.maps.CustomOverlay({
+      map,
+      position: new window.kakao.maps.LatLng(place.y, place.x),
+      content,
+      yAnchor: 1,
+    });
+    overlay.placeId = place.id;
+    customOverlaysRef.current.push(overlay);
+  };
+
+  // --- 장소 검색 ---
+  const fetchLocations = (map, lat, lng, category) => {
     const places = new window.kakao.maps.services.Places();
-      
-      // 현재 맵 영역(바운드) 가져오기
-      const bounds = map.getBounds();
-      const swLatLng = bounds.getSouthWest();
-      const neLatLng = bounds.getNorthEast();
-      
-      // 맵 중앙에서 현재 보이는 영역 내에서 검색 거리 계산
-      const latDiff = Math.abs(neLatLng.getLat() - swLatLng.getLat());
-      const lngDiff = Math.abs(neLatLng.getLng() - swLatLng.getLng());
-      
-      // 현재 맵 줌 레벨에 맞게 검색 반경 조정 (미터 단위)
-      // 줌 레벨이 작을수록(더 확대됨) 검색 반경도 작게
-      const zoomLevel = map.getLevel();
-      const searchRadius = Math.min(2000, 500 * zoomLevel);
-      
-      console.log(`검색 반경: ${searchRadius}m, 줌 레벨: ${zoomLevel}`);
-      
-    const callback = (result, status) => {
-      if (status === window.kakao.maps.services.Status.OK) {
-          console.log(`검색 결과: ${result.length}개 장소 발견`);
-          
-          // 현재 맵 영역 안에 있는 장소만 필터링
-          const filteredResults = result.filter(place => {
-            const placePos = new window.kakao.maps.LatLng(place.y, place.x);
-            return bounds.contain(placePos);
-          });
-          
-          console.log(`지도 영역 내 필터링 결과: ${filteredResults.length}개 장소`);
-          setLocations(filteredResults);
-          
-          // 모든 기존 오버레이 제거 확인
-          if (customOverlaysRef.current.length > 0) {
-            console.warn('이전 마커가 남아있어 모두 제거합니다.');
-            clearMarkers();
-          }
-          
-          // 커스텀 마커 생성
-          const newOverlays = filteredResults.map((place) => {
-            return createCustomMarker(map, place);
-          }).filter(overlay => overlay !== null); // null 값 제거
-          
-          customOverlaysRef.current = newOverlays;
-          console.log(`${newOverlays.length}개의 새 마커가 생성되었습니다.`);
-      } else {
-          console.error('검색 결과가 없습니다:', status);
-          setLocations([]);
-      }
-    };
+    const level = map.getLevel();
+    const radius = ZOOM_RADIUS_MAP[level] || 500;
 
-    places.keywordSearch(keyword, callback, {
-      location: new window.kakao.maps.LatLng(lat, lng),
-        radius: searchRadius,
-        sort: window.kakao.maps.services.SortBy.DISTANCE
-      });
-    } catch (error) {
-      console.error('위치 검색 중 오류 발생:', error);
-      setLocations([]);
-    }
+    places.keywordSearch(
+      category,
+      (data, status) => {
+        if (status === window.kakao.maps.services.Status.OK) {
+          setLocations(data);
+          data.forEach(place => createCustomMarker(map, place));
+        } else {
+          setLocations([]);
+        }
+      },
+      {
+        location: new window.kakao.maps.LatLng(lat, lng),
+        radius,
+        sort: window.kakao.maps.services.SortBy.DISTANCE,
+      }
+    );
   };
 
-  const handleKeywordChange = (keyword) => {
-    if (keyword === selectedCategory) return; // 같은 카테고리면 무시
-    
+  // --- 카테고리 변경 ---
+  const handleCategoryChange = useCallback((keyword) => {
     setSelectedCategory(keyword);
-    // 선택한 카테고리를 localStorage에 저장
-    localStorage.setItem('lastSelectedCategory', keyword);
-    
-    if (currentLocation && mapRef.current) {
-      // 카테고리 변경 시 마커 초기화 후 주변 검색 실행
+    localStorage.setItem(LS_KEYS.LAST_CATEGORY, keyword);
+    setSelectedPlace(null);
+    setShowResearch(false);
+
+    if (mapRef.current && currentLocation) {
       clearMarkers();
       fetchLocations(mapRef.current, currentLocation.latitude, currentLocation.longitude, keyword);
     }
-  };
+  }, [currentLocation]);
 
-  const handleSearch = () => {
-    if (!searchQuery.trim()) {
-      alert('검색어를 입력해주세요.');
-      return;
-    }
-
+  // --- 주소 검색 ---
+  const handleSearch = useCallback((queryOverride) => {
+    const query = queryOverride || searchQuery;
+    if (!query.trim() || !mapRef.current) return;
     setIsSearching(true);
-    // 기존 마커 초기화
-    clearMarkers();
-    
+
     const geocoder = new window.kakao.maps.services.Geocoder();
-    
-    geocoder.addressSearch(searchQuery, (result, status) => {
-      setIsSearching(false);
-      if (status === window.kakao.maps.services.Status.OK) {
-        const coords = new window.kakao.maps.LatLng(result[0].y, result[0].x);
-        
-        // 기존 현재 위치 마커 업데이트
-        if (currentLocationMarker.current) {
-          currentLocationMarker.current.setPosition(coords);
-        } else {
-        const marker = new window.kakao.maps.Marker({
-          map: mapRef.current,
-          position: coords,
-            title: "검색 위치",
-            image: new window.kakao.maps.MarkerImage(
-              "http://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_blue.png",
-              new window.kakao.maps.Size(24, 35),
-              { offset: new window.kakao.maps.Point(12, 35) }
-            ),
-        });
-        currentLocationMarker.current = marker;
-        }
-        
-        setCurrentLocation({ latitude: result[0].y, longitude: result[0].x });
-        mapRef.current.setCenter(coords);
-        
-        // 검색 시에는 주변 검색 실행
-        fetchLocations(mapRef.current, result[0].y, result[0].x, selectedCategory);
-      } else {
-        alert('주소를 찾을 수 없습니다.');
-      }
-    });
-  };
-
-  // 마커 클릭 시 상세 정보 표시
-  const handleLocationClick = (place) => {
-    if (!place || !place.y || !place.x) {
-      console.error('유효하지 않은 장소 데이터:', place);
-      return;
-    }
-    
-    const clickedPlace = {
-      id: place.id,
-      name: place.place_name,
-      address: place.address_name,
-      image: place.image_url,
-      position: { lat: place.y, lng: place.x },
-      phone: place.phone,
-      category_name: place.category_name,
-      place_url: place.place_url,
-      rating: "4.5" // 예시 값, 실제 구현에서는 DB에서 가져와야 함
-    };
-    
-    setSelectedPlace(clickedPlace);
-    
-    // 지도 중심 이동
-    if (mapRef.current) {
-    mapRef.current.setCenter(new window.kakao.maps.LatLng(place.y, place.x));
-    }
-  };
-
-  // 선택된 장소 정보 패널 닫기
-  const closeDetailSection = () => {
-    setSelectedPlace(null);
-    setShowReviewForm(false);
-    
-    // 모바일에서 닫을 때 바운스 효과 추가
-    if (isMobile && mapRef.current) {
-      const currentCenter = mapRef.current.getCenter();
-      // 살짝 줌 아웃했다가 다시 원래 레벨로 돌아오는 애니메이션
-      const currentLevel = mapRef.current.getLevel();
-      mapRef.current.setLevel(currentLevel + 1, {animate: true});
-      setTimeout(() => {
-        mapRef.current.setLevel(currentLevel, {animate: true});
-      }, 100);
-    }
-  };
-
-  const recenterMap = () => {
-    if (currentLocation && mapRef.current) {
-      const moveLatLon = new window.kakao.maps.LatLng(
-        currentLocation.latitude,
-        currentLocation.longitude
-      );
-      mapRef.current.setCenter(moveLatLon);
-      if (currentLocationMarker.current) {
-        currentLocationMarker.current.setPosition(moveLatLon);
-      }
-    }
-  };
-
-  // 현재 위치로 이동하는 함수
-  const moveToCurrentLocation = () => {
-    // 기존 마커 초기화
-    clearMarkers();
-    
-    getUserCurrentLocation();
-    // 현재 위치로 이동 시에는 주변 검색 실행
-    if (currentLocation && mapRef.current) {
-      fetchLocations(mapRef.current, currentLocation.latitude, currentLocation.longitude, selectedCategory);
-    }
-  };
-  
-  // 리뷰 입력 핸들러
-  const handleReviewChange = (e) => {
-    const { name, value } = e.target;
-    setNewReview(prev => ({
-      ...prev,
-      [name]: value
-    }));
-  };
-  
-  // 별점 변경 핸들러
-  const handleRatingChange = (rating) => {
-    setNewReview(prev => ({
-      ...prev,
-      rating
-    }));
-  };
-  
-  // 리뷰 제출 핸들러
-  const handleReviewSubmit = (e) => {
-    e.preventDefault();
-    
-    // 필수 입력값 검증
-    if (!newReview.userName.trim() || !newReview.content.trim()) {
-      alert('이름과 리뷰 내용을 입력해주세요.');
-      return;
-    }
-    
-    // 새 리뷰 객체 생성
-    const reviewToAdd = {
-      id: Date.now(), // 임시 ID 생성
-      userName: newReview.userName,
-      rating: newReview.rating,
-      content: newReview.content,
-      date: new Date().toISOString().split('T')[0], // 현재 날짜
-      place_id: selectedPlace.id // 장소 ID 연결
-    };
-    
-    // TODO: 실제 구현에서는 리뷰 데이터를 서버에 저장하는 API 호출 필요
-    // saveReviewToDatabase(reviewToAdd).then(() => {
-    //   // 성공적으로 저장 후 리뷰 목록 갱신
-    // });
-    
-    // 임시로 리뷰 목록에 추가
-    setReviews(prev => [reviewToAdd, ...prev]);
-    
-    // 입력 폼 초기화
-    setNewReview({ userName: '', rating: 5, content: '' });
-    setShowReviewForm(false);
-  };
-
-  // 컴포넌트 마운트 시 기본 카테고리로 초기 로드
-  useEffect(() => {
-    if (currentLocation && mapRef.current && selectedCategory) {
-      console.log('위치 또는 카테고리가 변경되어 주변 검색을 시작합니다.');
-      // 이전 마커 제거 후 새로운 검색 실행
-      clearMarkers();
-      fetchLocations(mapRef.current, currentLocation.latitude, currentLocation.longitude, selectedCategory);
-    }
-  }, [currentLocation, selectedCategory]);
-
-  // 지도가 로드될 때 이벤트 핸들러
-  useEffect(() => {
-    // 컴포넌트 언마운트 시 모든 마커와 오버레이 제거
-    return () => {
-      if (markersRef.current.length > 0 || customOverlaysRef.current.length > 0) {
-        console.log('컴포넌트 언마운트: 모든 마커와 오버레이를 제거합니다.');
+    geocoder.addressSearch(query, (result, status) => {
+      if (status === window.kakao.maps.services.Status.OK && result.length > 0) {
+        const { y, x } = result[0];
+        const latlng = new window.kakao.maps.LatLng(y, x);
+        mapRef.current.setCenter(latlng);
+        setCurrentLocation({ latitude: Number(y), longitude: Number(x) });
+        updateCurrentLocationMarker(mapRef.current, latlng);
         clearMarkers();
+        fetchLocations(mapRef.current, y, x, selectedCategory);
+      } else {
+        // 주소 검색 실패 시 키워드로 장소 검색
+        const places = new window.kakao.maps.services.Places();
+        places.keywordSearch(query, (data, status2) => {
+          if (status2 === window.kakao.maps.services.Status.OK && data.length > 0) {
+            const first = data[0];
+            const latlng = new window.kakao.maps.LatLng(first.y, first.x);
+            mapRef.current.setCenter(latlng);
+            setCurrentLocation({ latitude: Number(first.y), longitude: Number(first.x) });
+            updateCurrentLocationMarker(mapRef.current, latlng);
+            clearMarkers();
+            setLocations(data);
+            data.forEach(place => createCustomMarker(mapRef.current, place));
+          }
+        });
       }
-    };
+      setIsSearching(false);
+    });
+  }, [searchQuery, selectedCategory]);
+
+  // --- 장소 클릭 ---
+  const handlePlaceClick = useCallback((place) => {
+    setSelectedPlace(place);
+    if (mapRef.current) {
+      mapRef.current.panTo(new window.kakao.maps.LatLng(place.y, place.x));
+    }
   }, []);
 
-  // 모바일/데스크톱 변경 시 마커 재생성
-  useEffect(() => {
-    if (mapRef.current && currentLocation) {
-      console.log('화면 크기 변경으로 마커를 초기화합니다.');
-      clearMarkers();
-      fetchLocations(
-        mapRef.current, 
-        currentLocation.latitude, 
-        currentLocation.longitude, 
-        selectedCategory
-      );
-    }
-  }, [isMobile]);
+  // --- 줌 ---
+  const handleZoomIn = useCallback(() => {
+    if (mapRef.current) mapRef.current.setLevel(mapRef.current.getLevel() - 1);
+  }, []);
 
-  // 디버깅: 선택된 장소 정보 확인
-  useEffect(() => {
-    if (selectedPlace) {
-      console.log('Selected Place:', selectedPlace);
-      if (!selectedPlace.position || !selectedPlace.position.lat || !selectedPlace.position.lng) {
-        console.warn('위치 정보가 없거나 잘못되었습니다:', selectedPlace);
-      }
-    }
-  }, [selectedPlace]);
+  const handleZoomOut = useCallback(() => {
+    if (mapRef.current) mapRef.current.setLevel(mapRef.current.getLevel() + 1);
+  }, []);
+
+  // --- 내 위치 ---
+  const handleMyLocation = useCallback(() => {
+    getUserCurrentLocation();
+  }, []);
+
+  // --- 이 지역 재검색 (네이버맵 스타일) ---
+  const handleResearchArea = useCallback(() => {
+    if (!mapRef.current) return;
+    const center = mapRef.current.getCenter();
+    const lat = center.getLat();
+    const lng = center.getLng();
+    setCurrentLocation({ latitude: lat, longitude: lng });
+    clearMarkers();
+    fetchLocations(mapRef.current, lat, lng, selectedCategory);
+    setShowResearch(false);
+  }, [selectedCategory]);
 
   return (
     <KakaoMapView
-      isMobile={isMobile}
       mapContainerRef={mapContainerRef}
       locations={locations}
       selectedPlace={selectedPlace}
-      closeDetailSection={closeDetailSection}
-      recenterMap={recenterMap}
-      handleKeywordChange={handleKeywordChange}
-      categories={categories}
+      onCloseDetail={() => { setSelectedPlace(null); }}
       selectedCategory={selectedCategory}
-      handleLocationClick={handleLocationClick}
+      onCategoryChange={handleCategoryChange}
       searchQuery={searchQuery}
       setSearchQuery={setSearchQuery}
-      handleSearch={handleSearch}
+      onSearch={handleSearch}
       isSearching={isSearching}
-      openList={openList}
-      toggleList={toggleList}
-      moveToCurrentLocation={moveToCurrentLocation}
+      onPlaceClick={handlePlaceClick}
+      onZoomIn={handleZoomIn}
+      onZoomOut={handleZoomOut}
+      onMyLocation={handleMyLocation}
       isLoadingLocation={isLoadingLocation}
-      locationError={locationError}
-      // 리뷰 관련 props
       reviews={reviews}
-      newReview={newReview}
-      handleReviewChange={handleReviewChange}
-      handleRatingChange={handleRatingChange}
-      handleReviewSubmit={handleReviewSubmit}
-      showReviewForm={showReviewForm}
-      setShowReviewForm={setShowReviewForm}
+      favorites={favorites}
+      isFavorite={isFavorite}
+      onToggleFavorite={toggleFavorite}
+      showFavorites={showFavorites}
+      onToggleShowFavorites={() => setShowFavorites(prev => !prev)}
+      showResearch={showResearch}
+      onResearchArea={handleResearchArea}
     />
   );
 };

--- a/src/hooks/map/useFavorites.js
+++ b/src/hooks/map/useFavorites.js
@@ -1,0 +1,53 @@
+import { useState, useCallback } from 'react';
+import { LS_KEYS } from '../../utils/mapConstants';
+
+/**
+ * 지도 즐겨찾기 관리 훅 (localStorage 기반)
+ */
+export default function useFavorites() {
+  const [favorites, setFavorites] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem(LS_KEYS.FAVORITES) || '[]');
+    } catch {
+      return [];
+    }
+  });
+
+  const saveFavorites = useCallback((next) => {
+    setFavorites(next);
+    localStorage.setItem(LS_KEYS.FAVORITES, JSON.stringify(next));
+  }, []);
+
+  const isFavorite = useCallback((placeId) => {
+    return favorites.some(f => f.id === placeId);
+  }, [favorites]);
+
+  const addFavorite = useCallback((place) => {
+    if (isFavorite(place.id)) return;
+    const item = {
+      id: place.id,
+      place_name: place.place_name,
+      address_name: place.address_name,
+      phone: place.phone,
+      x: place.x,
+      y: place.y,
+      category_name: place.category_name,
+      place_url: place.place_url,
+    };
+    saveFavorites([item, ...favorites]);
+  }, [favorites, isFavorite, saveFavorites]);
+
+  const removeFavorite = useCallback((placeId) => {
+    saveFavorites(favorites.filter(f => f.id !== placeId));
+  }, [favorites, saveFavorites]);
+
+  const toggleFavorite = useCallback((place) => {
+    if (isFavorite(place.id)) {
+      removeFavorite(place.id);
+    } else {
+      addFavorite(place);
+    }
+  }, [isFavorite, addFavorite, removeFavorite]);
+
+  return { favorites, isFavorite, addFavorite, removeFavorite, toggleFavorite };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -96,6 +96,17 @@ html.dark ::-webkit-scrollbar-thumb { background: #555; }
   }
 }
 
+/* ── 스크롤바 숨기기 유틸리티 ───────────────────────────────── */
+@layer utilities {
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 /* ── Draft.js 에디터 필수 스타일 ───────────────────────────────── */
 .DraftEditor-root {
   position: relative;

--- a/src/pages/map/KakaoMapPage.jsx
+++ b/src/pages/map/KakaoMapPage.jsx
@@ -1,70 +1,32 @@
 import React, { useState, useEffect } from 'react';
 import KakaoMapContainer from '../../containers/map/KakaoMapContainer';
-import { Box, CircularProgress, Typography } from '@mui/joy';
 
+/**
+ * 지도 페이지 — MUI 완전 제거, Tailwind 로딩
+ */
 const KakaoMapPage = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // 2초 후 로딩 상태 해제
-    const timer = setTimeout(() => {
-      setLoading(false);
-    }, 2000);
-
+    const timer = setTimeout(() => setLoading(false), 1200);
     return () => clearTimeout(timer);
   }, []);
 
   if (loading) {
     return (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100vh',
-          width: '100vw',
-          backgroundColor: '#FAF8F5',
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          zIndex: 9999
-        }}
-      >
-        <img 
-          src="/images/borikkori_cartoon_1.png" 
-          alt="보리꼬리 로딩" 
-          style={{ 
-            maxWidth: '300px',
-            marginBottom: '20px',
-            animation: 'bounce 1s infinite alternate'
-          }} 
+      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center
+                       bg-secondary dark:bg-dark-surface transition-colors duration-200">
+        <img
+          src="/images/borikkori_cartoon_1.png"
+          alt="보리꼬리 로딩"
+          className="max-w-[250px] md:max-w-[300px] animate-bounce"
         />
-        <Typography 
-          level="title-lg" 
-          sx={{ 
-            color: '#8B5E3C', 
-            fontWeight: 'bold',
-            marginTop: '16px'
-          }}
-        >
-          지도를 불러오는 중입니다...
-        </Typography>
-        <CircularProgress 
-          size="sm" 
-          sx={{ 
-            color: '#8B5E3C', 
-            marginTop: '16px' 
-          }} 
-        />
-        
-        <style jsx="true">{`
-          @keyframes bounce {
-            from { transform: translateY(0px); }
-            to { transform: translateY(-15px); }
-          }
-        `}</style>
-      </Box>
+        <p className="mt-4 text-lg font-bold text-primary dark:text-primary-light text-center">
+          지도를 불러오는 중...
+        </p>
+        <div className="mt-3 w-6 h-6 border-2 border-primary dark:border-accent
+                        border-t-transparent rounded-full animate-spin" />
+      </div>
     );
   }
 

--- a/src/utils/mapConstants.js
+++ b/src/utils/mapConstants.js
@@ -1,0 +1,57 @@
+/**
+ * 지도 관련 상수
+ */
+
+// 카테고리 정의 (이모지 + 라벨)
+export const CATEGORIES = [
+  { key: 'petShop', label: '애견샵', emoji: '🐾', keyword: '애견샵' },
+  { key: 'animalHospital', label: '동물병원', emoji: '🏥', keyword: '동물병원' },
+  { key: 'petCafe', label: '애견카페', emoji: '☕', keyword: '애견카페' },
+  { key: 'dogPark', label: '공원', emoji: '🌳', keyword: '강아지 공원' },
+  { key: 'dogHotel', label: '호텔', emoji: '🏨', keyword: '강아지 호텔' },
+];
+
+// 카테고리 키워드 → 이모지 매핑
+export const CATEGORY_EMOJI_MAP = Object.fromEntries(
+  CATEGORIES.map(c => [c.keyword, c.emoji])
+);
+
+// 기본 위치 (서울 시청)
+export const DEFAULT_LOCATION = { latitude: 37.5665, longitude: 126.9780 };
+
+// 줌 레벨별 검색 반경 (m)
+export const ZOOM_RADIUS_MAP = {
+  1: 2000, 2: 2000, 3: 1500, 4: 1000, 5: 800,
+  6: 500, 7: 500, 8: 300, 9: 200, 10: 100,
+};
+
+// localStorage 키
+export const LS_KEYS = {
+  FAVORITES: 'map_favorites',
+  RECENT_SEARCHES: 'map_recent_searches',
+  LAST_CATEGORY: 'lastSelectedCategory',
+};
+
+// 더미 리뷰
+export const DUMMY_REVIEWS = [
+  { id: 1, userName: '강아지러버', rating: 5, content: '정말 좋은 곳이에요! 강아지와 함께 편안하게 시간을 보낼 수 있었습니다.', date: '2023-05-15' },
+  { id: 2, userName: '멍멍이맘', rating: 4, content: '직원분들이 친절하고 시설도 깨끗해요.', date: '2023-06-20' },
+  { id: 3, userName: '포메러브', rating: 3, content: '괜찮은 곳이지만 주차가 조금 불편해요.', date: '2023-07-10' },
+];
+
+// 길찾기 URL 생성
+export function getDirectionsUrl(place, provider = 'kakao') {
+  const { place_name, y, x } = place;
+  if (provider === 'kakao') {
+    return `https://map.kakao.com/link/to/${encodeURIComponent(place_name)},${y},${x}`;
+  }
+  // 네이버
+  return `https://map.naver.com/v5/search/${encodeURIComponent(place_name)}`;
+}
+
+// 한국 행정구역 (검색 자동완성용)
+export const KOREA_LOCATIONS = {
+  서울: { 강남구: ['청담동', '삼성동', '역삼동'], 강서구: ['화곡동', '등촌동'], 종로구: ['종로1가', '종로2가'] },
+  부산: { 해운대구: ['우동', '중동'], 남구: ['용호동', '감만동'], 동래구: ['명륜동', '온천동'] },
+  대구: { 달서구: ['성당동', '두류동'], 중구: ['봉산동', '대신동'] },
+};


### PR DESCRIPTION
- 모놀리식 코드(2,270줄) → 11개 모듈로 분리 (hooks, utils, components)
- MUI/인라인 스타일 → Tailwind CSS + 다크모드 전체 지원
- 글래스모피즘 검색바 (backdrop-blur, 최근 검색어 드롭다운)
- 카테고리 칩에 결과 카운트 배지 표시
- 모바일 바텀시트 (접힘/반펼침/전체 3단계 터치 드래그)
- 장소 상세: 전화/길찾기/저장/공유 액션 버튼, 리뷰 UI
- 네이버맵 스타일 "이 지역 재검색" 플로팅 버튼
- 즐겨찾기 기능 (localStorage 기반)
- 줌/내위치 컨트롤 글래스모피즘 적용